### PR TITLE
Allow configurable file descriptor limit

### DIFF
--- a/src/FatController.cpp
+++ b/src/FatController.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <sys/time.h>
 #include <sys/poll.h>
+#include <sys/resource.h>
 
 // LINUX ONLY FEATURE
 //#ifdef HAVE_SYS_EPOLL_H
@@ -1373,6 +1374,14 @@ int fc_controlit()   //
 
     o.lm.garbageCollect();
     thread_id = "master: ";
+    struct rlimit rl;
+    rl.rlim_cur = rl.rlim_max = o.desired_fd_limit;
+    if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+        if (!is_daemonised) {
+            std::cerr << thread_id << "Unable to set file descriptor limit" << std::endl;
+        }
+        syslog(LOG_ERR, "%sUnable to set file descriptor limit", thread_id.c_str());
+    }
 
     // allocate & create our server sockets
     if (o.map_ports_to_ips) {

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -198,17 +198,22 @@ bool OptionContainer::read(std::string& filename, int type)
 			e2_front_log = false;
 		}
 
-		if (findoptionS("nologger") == "on") {
-			no_logger = true;
-		} else {
-			no_logger = false;
-		}
+                if (findoptionS("nologger") == "on") {
+                        no_logger = true;
+                } else {
+                        no_logger = false;
+                }
 
-		if (findoptionS("softrestart") == "on") {
-			soft_restart = true;
-		} else {
-			soft_restart = false;
-		}
+                if (findoptionS("softrestart") == "on") {
+                        soft_restart = true;
+                } else {
+                        soft_restart = false;
+                }
+
+                desired_fd_limit = findoptionI("desiredfdlimit");
+                if (desired_fd_limit == 0) {
+                        desired_fd_limit = 65535;
+                }
 
 #ifdef __SSLMITM
         ssl_certificate_path = findoptionS("sslcertificatepath") + "/";

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -163,6 +163,7 @@ class OptionContainer
     bool log_timestamp = false;
     bool log_user_agent = false;
     bool soft_restart = false;
+    unsigned int desired_fd_limit = 65535;
 
 #ifdef __SSLMITM
     std::string ssl_certificate_path;


### PR DESCRIPTION
## Summary
- add `desired_fd_limit` option to configuration
- set RLIMIT_NOFILE in FatController before creating sockets

## Testing
- `./autogen.sh` *(fails: aclocal: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e959d8d88832e99ef30cd96b7c95d