### PR TITLE
Enable FreeBSD SO_REUSEPORT for socket bind

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -242,6 +242,9 @@ int Socket::bind(int port) {
     int i = 1;
 
     setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i));
+#ifdef __FreeBSD__
+    setsockopt(sck, SOL_SOCKET, SO_REUSEPORT, &i, sizeof(i));
+#endif
 
     my_adr.sin_port = htons(port);
     my_port = port;
@@ -255,6 +258,9 @@ int Socket::bind(const std::string &ip, int port) {
     int i = 1;
 
     setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i));
+#ifdef __FreeBSD__
+    setsockopt(sck, SOL_SOCKET, SO_REUSEPORT, &i, sizeof(i));
+#endif
 
     my_adr.sin_port = htons(port);
     my_adr.sin_addr.s_addr = inet_addr(ip.c_str());


### PR DESCRIPTION
## Summary
- support multiple listeners on FreeBSD by setting `SO_REUSEPORT` in both `Socket::bind` variants

## Testing
- `g++ -c src/Socket.cpp -o /tmp/Socket.o` *(fails: `String::String(off_t)` cannot be overloaded with `String::String(long int)`)*

------
https://chatgpt.com/codex/tasks/task_e_689e972cba9c832ea706a9ca762b0bbb