### PR TITLE
Guard sockets with CLOEXEC and NONBLOCK

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -275,7 +275,24 @@ Socket *Socket::accept() {
     s_errno = 0;
     errno = 0;
 //    int newfd = this->baseAccept((struct sockaddr *)&peer_adr, &peer_adr_length);
+#ifdef HAVE_ACCEPT4
+    int newfd = ::accept4(sck, (struct sockaddr *) &peer_adr, &peer_adr_length,
+        SOCK_CLOEXEC | SOCK_NONBLOCK);
+#else
     int newfd = ::accept(sck, (struct sockaddr *) &peer_adr, &peer_adr_length);
+    if (newfd > 0) {
+        int flags;
+        if ((flags = fcntl(newfd, F_GETFD)) == -1 ||
+            fcntl(newfd, F_SETFD, flags | FD_CLOEXEC) == -1 ||
+            (flags = fcntl(newfd, F_GETFL)) == -1 ||
+            fcntl(newfd, F_SETFL, flags | O_NONBLOCK) == -1) {
+            int e = errno;
+            ::close(newfd);
+            s_errno = e;
+            return NULL;
+        }
+    }
+#endif
 
     if (newfd > 0) {
         Socket *s = new Socket(newfd, my_adr, peer_adr);


### PR DESCRIPTION
## Summary
- use `accept4` with `SOCK_CLOEXEC | SOCK_NONBLOCK` when available
- fall back to `accept` followed by `fcntl` to set `FD_CLOEXEC` and `O_NONBLOCK`
- propagate `errno` via `s_errno` and close descriptors on failure

## Testing
- `./autogen.sh` *(fails: aclocal not found)*
- `g++ -std=c++17 -c src/Socket.cpp -Isrc -I.` *(fails: String::String(off_t) cannot be overloaded)*

------
https://chatgpt.com/codex/tasks/task_e_689e9cc5ee70832e9375c92b808c8329