### PR TITLE
Add debug logging for socket closure

### DIFF
--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -82,10 +82,9 @@ BaseSocket::BaseSocket(int fd)
 // destructor - close socket
 BaseSocket::~BaseSocket()
 {
-    // close fd if socket not used
-    if (sck > -1) {
-        ::close(sck);
-    }
+    // ensure the socket is closed using the common close handler so we
+    // get consistent logging behaviour.
+    close();
 }
 
 // reset - close socket & reset timeout.
@@ -146,7 +145,12 @@ int BaseSocket::getFD()
 void BaseSocket::close()
 {
     if (sck > -1) {
-        ::close(sck);
+        int fd = sck;
+        syslog(LOG_DEBUG, "%sClosing fd %d", thread_id.c_str(), fd);
+        if (::close(fd) < 0) {
+            int err = errno;
+            syslog(LOG_ERR, "%sFailed to close fd %d: %s", thread_id.c_str(), fd, strerror(err));
+        }
         sck = -1;
         infds[0].fd = -1;
         outfds[0].fd = -1;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -47,6 +47,9 @@ extern thread_local std::string thread_id;
 //
 // destructor
 Socket::~Socket() {
+    if (sck > -1) {
+        syslog(LOG_DEBUG, "%sSocket destructor closing fd %d", thread_id.c_str(), sck);
+    }
     close();
 }
 


### PR DESCRIPTION
## Summary
- log file descriptor and errors when closing sockets
- add destructor logging for sockets

## Testing
- `g++ -std=c++17 -DHAVE_CONFIG_H -I. -Isrc -c src/BaseSocket.cpp` *(fails: fatal error: dgconfig.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ea153e71c832ea0608ec2913488cf