### PR TITLE
Ensure sockets are closed on accept errors

### DIFF
--- a/doc/fd_leak_test.md
+++ b/doc/fd_leak_test.md
@@ -1,0 +1,16 @@
+# File descriptor leak test
+
+This manual test verifies that `Socket::accept` closes file descriptors on error.
+
+1. Build and run e2guardian normally.
+2. In another shell, reduce the available descriptor limit and create many client
+   connections to force `accept` or `fcntl` failures:
+   ```bash
+   ulimit -n 10
+   for i in {1..20}; do nc localhost 8080 & done
+   wait
+   ```
+3. Inspect the e2guardian logs.  Each failure should include a message such as
+   `accept4 failed` or `fcntl failed` and no "leaked fd" warnings should appear.
+4. Optionally monitor the process with `lsof` to confirm that descriptor counts
+   return to baseline after the test.

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -281,19 +281,36 @@ Socket *Socket::accept() {
 #ifdef HAVE_ACCEPT4
     int newfd = ::accept4(sck, (struct sockaddr *) &peer_adr, &peer_adr_length,
         SOCK_CLOEXEC | SOCK_NONBLOCK);
+    if (newfd < 0) {
+        int e = errno;
+        syslog(LOG_ERR, "%saccept4 failed: %s", thread_id.c_str(), strerror(e));
+        if (newfd >= 0) {
+            ::close(newfd);
+        }
+        s_errno = e;
+        return NULL;
+    }
 #else
     int newfd = ::accept(sck, (struct sockaddr *) &peer_adr, &peer_adr_length);
-    if (newfd > 0) {
-        int flags;
-        if ((flags = fcntl(newfd, F_GETFD)) == -1 ||
-            fcntl(newfd, F_SETFD, flags | FD_CLOEXEC) == -1 ||
-            (flags = fcntl(newfd, F_GETFL)) == -1 ||
-            fcntl(newfd, F_SETFL, flags | O_NONBLOCK) == -1) {
-            int e = errno;
+    if (newfd < 0) {
+        int e = errno;
+        syslog(LOG_ERR, "%saccept failed: %s", thread_id.c_str(), strerror(e));
+        if (newfd >= 0) {
             ::close(newfd);
-            s_errno = e;
-            return NULL;
         }
+        s_errno = e;
+        return NULL;
+    }
+    int flags;
+    if ((flags = fcntl(newfd, F_GETFD)) == -1 ||
+        fcntl(newfd, F_SETFD, flags | FD_CLOEXEC) == -1 ||
+        (flags = fcntl(newfd, F_GETFL)) == -1 ||
+        fcntl(newfd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        int e = errno;
+        syslog(LOG_ERR, "%sfcntl failed on fd %d: %s", thread_id.c_str(), newfd, strerror(e));
+        ::close(newfd);
+        s_errno = e;
+        return NULL;
     }
 #endif
 
@@ -301,10 +318,14 @@ Socket *Socket::accept() {
         Socket *s = new Socket(newfd, my_adr, peer_adr);
         s->setPort(my_port);
         return s;
-    } else {
-        s_errno = errno;
-        return NULL;
     }
+
+    if (newfd >= 0) {
+        ::close(newfd);
+    }
+    s_errno = errno;
+    syslog(LOG_ERR, "%saccept returned invalid fd %d", thread_id.c_str(), newfd);
+    return NULL;
 }
 
 #ifdef __SSLMITM


### PR DESCRIPTION
## Summary
- log and close fds when accept/accept4/fcntl fails
- document manual steps to verify no file descriptor leaks

## Testing
- `g++ -std=c++17 -DHAVE_ACCEPT4 -Isrc -c src/Socket.cpp -o /tmp/Socket.o` *(fails: ‘String::String(off_t)’ cannot be overloaded with ‘String::String(long int)’)*

------
https://chatgpt.com/codex/tasks/task_e_689ea324b6cc832e9796dfca9c6fa8c3