### PR TITLE
Add FreeBSD kqueue event handling

### DIFF
--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -19,6 +19,9 @@
 #include <stdexcept>
 #include <syslog.h>
 #include <sys/select.h>
+#ifdef __FreeBSD__
+#include <sys/event.h>
+#endif
 
 #ifdef NETDEBUG
 #include <iostream>
@@ -228,6 +231,40 @@ bool BaseSocket::bcheckSForInput(int timeout)
     int rc;
     s_errno = 0;
     errno = 0;
+#ifdef __FreeBSD__
+    int kq = kqueue();
+    if (kq == -1) {
+        s_errno = errno;
+        sockerr = true;
+        return false;
+    }
+    struct kevent change;
+    struct kevent event;
+    EV_SET(&change, sck, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    struct timespec ts;
+    ts.tv_sec = timeout / 1000;
+    ts.tv_nsec = (timeout % 1000) * 1000000;
+    rc = kevent(kq, &change, 1, &event, 1, &ts);
+    close(kq);
+    if (rc == 0) {
+        timedout = true;
+        return false;
+    }
+    timedout = false;
+    if (rc < 0 || (event.flags & EV_ERROR)) {
+        s_errno = (rc < 0) ? errno : event.data;
+        sockerr = true;
+        return false;
+    }
+    if (event.flags & EV_EOF) {
+        ishup = true;
+    }
+    if (event.filter == EVFILT_READ) {
+        return true;
+    }
+    sockerr = true;
+    return false;
+#else
     rc = poll(infds, 1, timeout);
     if (rc == 0)
     {
@@ -249,6 +286,7 @@ bool BaseSocket::bcheckSForInput(int timeout)
     }
     sockerr = true;
     return false;   // must be POLLERR or POLLNVAL
+#endif
 }
 
 // blocking check to see if there is data waiting on socket
@@ -261,6 +299,40 @@ bool BaseSocket::bcheckForInput(int timeout)
     int rc;
     s_errno = 0;
     errno = 0;
+#ifdef __FreeBSD__
+    int kq = kqueue();
+    if (kq == -1) {
+        s_errno = errno;
+        sockerr = true;
+        return false;
+    }
+    struct kevent change;
+    struct kevent event;
+    EV_SET(&change, sck, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    struct timespec ts;
+    ts.tv_sec = timeout / 1000;
+    ts.tv_nsec = (timeout % 1000) * 1000000;
+    rc = kevent(kq, &change, 1, &event, 1, &ts);
+    close(kq);
+    if (rc == 0) {
+        timedout = true;
+        return false;
+    }
+    timedout = false;
+    if (rc < 0 || (event.flags & EV_ERROR)) {
+        s_errno = (rc < 0) ? errno : event.data;
+        sockerr = true;
+        return false;
+    }
+    if (event.flags & EV_EOF) {
+        ishup = true;
+    }
+    if (event.filter == EVFILT_READ) {
+        return true;
+    }
+    sockerr = true;
+    return false;
+#else
     rc = poll(infds, 1, timeout);
     if (rc == 0)
     {
@@ -282,6 +354,7 @@ bool BaseSocket::bcheckForInput(int timeout)
     }
     sockerr = true;
     return false;   // must be POLLERR or POLLNVAL
+#endif
 }
 
 // blocking check for waiting data - blocks for up to given timeout, can be told to break on signal-triggered config reloads
@@ -294,6 +367,39 @@ bool BaseSocket::checkForInput()
     int rc;
     s_errno = 0;
     errno = 0;
+#ifdef __FreeBSD__
+    int kq = kqueue();
+    if (kq == -1) {
+        s_errno = errno;
+        sockerr = true;
+        return false;
+    }
+    struct kevent change;
+    struct kevent event;
+    EV_SET(&change, sck, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 0;
+    rc = kevent(kq, &change, 1, &event, 1, &ts);
+    close(kq);
+    if (rc == 0) {
+        return false;
+    }
+    timedout = false;
+    if (rc < 0 || (event.flags & EV_ERROR)) {
+        s_errno = (rc < 0) ? errno : event.data;
+        sockerr = true;
+        return false;
+    }
+    if (event.flags & EV_EOF) {
+        ishup = true;
+    }
+    if (event.filter == EVFILT_READ) {
+        return true;
+    }
+    sockerr = true;
+    return false;
+#else
    rc = poll(infds, 1, 0);
     if (rc == 0)
         {
@@ -314,6 +420,7 @@ bool BaseSocket::checkForInput()
     }
     sockerr = true;
     return false;   // must be POLLERR or POLLNVAL
+#endif
 }
 
 
@@ -326,6 +433,38 @@ bool BaseSocket::readyForOutput()
     int rc;
     s_errno = 0;
     errno = 0;
+#ifdef __FreeBSD__
+    int kq = kqueue();
+    if (kq == -1) {
+        s_errno = errno;
+        sockerr = true;
+        return false;
+    }
+    struct kevent change;
+    struct kevent event;
+    EV_SET(&change, sck, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 0;
+    rc = kevent(kq, &change, 1, &event, 1, &ts);
+    close(kq);
+    if (rc == 0) {
+        return false;
+    }
+    timedout = false;
+    if (rc < 0 || (event.flags & EV_ERROR)) {
+        s_errno = (rc < 0) ? errno : event.data;
+        sockerr = true;
+        return false;
+    }
+    if (event.flags & EV_EOF) {
+        ishup = true;
+    }
+    if (event.filter == EVFILT_WRITE) {
+        return true;
+    }
+    return false;
+#else
     rc = poll(outfds,1, 0);
     if (rc == 0)
     {
@@ -343,6 +482,7 @@ bool BaseSocket::readyForOutput()
     if (outfds[0].revents & POLLHUP)
         ishup = true;
     return false;
+#endif
 }
 
 bool BaseSocket::breadyForOutput(int timeout) {
@@ -351,6 +491,39 @@ bool BaseSocket::breadyForOutput(int timeout) {
     int rc;
     s_errno = 0;
     errno = 0;
+#ifdef __FreeBSD__
+    int kq = kqueue();
+    if (kq == -1) {
+        s_errno = errno;
+        sockerr = true;
+        return false;
+    }
+    struct kevent change;
+    struct kevent event;
+    EV_SET(&change, sck, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    struct timespec ts;
+    ts.tv_sec = timeout / 1000;
+    ts.tv_nsec = (timeout % 1000) * 1000000;
+    rc = kevent(kq, &change, 1, &event, 1, &ts);
+    close(kq);
+    if (rc == 0) {
+        timedout = true;
+        return false;
+    }
+    timedout = false;
+    if (rc < 0 || (event.flags & EV_ERROR)) {
+        s_errno = (rc < 0) ? errno : event.data;
+        sockerr = true;
+        return false;
+    }
+    if (event.flags & EV_EOF) {
+        ishup = true;
+    }
+    if (event.filter == EVFILT_WRITE) {
+        return true;
+    }
+    return false;
+#else
     rc = poll(outfds, 1, timeout);
     if (rc == 0) {
         timedout = true;
@@ -367,6 +540,7 @@ bool BaseSocket::breadyForOutput(int timeout) {
     if (outfds[0].revents & POLLHUP)
         ishup = true;
     return false;
+#endif
 }
 
 // read a line from the socket, can be told to break on config reloads

--- a/src/BaseSocket.hpp
+++ b/src/BaseSocket.hpp
@@ -17,6 +17,9 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <poll.h>
+#ifdef __FreeBSD__
+#include <sys/event.h>
+#endif
 
 int selectEINTR(int numfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout, bool honour_reloadconfig = false);
 

--- a/src/FDTunnel.cpp
+++ b/src/FDTunnel.cpp
@@ -21,6 +21,9 @@
 #include <string.h>
 #include <algorithm>
 #include <sys/select.h>
+#ifdef __FreeBSD__
+#include <sys/event.h>
+#endif
 
 #ifdef DGDEBUG
 #include <iostream>
@@ -96,6 +99,23 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
 
     fdfrom = sockfrom.getFD();
     fdto = sockto.getFD();
+#ifdef __FreeBSD__
+    int kq = kqueue();
+    if (kq == -1) {
+        return false;
+    }
+    struct kevent changes[2];
+    int nchanges = 0;
+    EV_SET(&changes[nchanges++], fdfrom, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    bool monitor_to = !(ignore && !twoway);
+    if (monitor_to) {
+        EV_SET(&changes[nchanges++], fdto, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    }
+    if (kevent(kq, changes, nchanges, NULL, 0, NULL) < 0) {
+        close(kq);
+        return false;
+    }
+#else
     fromoutfds[0].fd = fdfrom;
     fromoutfds[0].events = POLLOUT;
     tooutfds[0].fd = fdto;
@@ -109,12 +129,125 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
     }
     else
         twayfds[1].fd = fdto;
+#endif
 
     char buff[32768]; // buffer for the input
     int timeout = 120000;    // should be made setable in conf files
 
     bool done = false; // so we get past the first while
 
+#ifdef __FreeBSD__
+    while (!done && (targetthroughput > -1 ? throughput < targetthroughput : true)) {
+        done = true; // if we don't make a successful read and write this flag will stay true
+#ifdef DGDEBUG
+        std::cout <<thread_id << "Start of tunnel loop: throughput:" << throughput
+            << " target:"  << targetthroughput  << std::endl;
+#endif
+
+#ifdef __SSLMITM
+        bool from_ready = false;
+        bool to_ready = false;
+        if (sockfrom.isSsl()) {
+            from_ready = true;
+        } else
+#else
+        bool from_ready = false;
+        bool to_ready = false;
+#endif
+        {
+            struct kevent events[2];
+            struct timespec ts;
+            ts.tv_sec = timeout / 1000;
+            ts.tv_nsec = (timeout % 1000) * 1000000;
+            int rc = kevent(kq, NULL, 0, events, nchanges, &ts);
+            if (rc < 1) {
+#ifdef DGDEBUG
+                std::cout <<thread_id << "tunnel tw kqueue returned error or timeout::" << rc
+                    << std::endl;
+#endif
+                break;
+            }
+#ifdef DGDEBUG
+            std::cout <<thread_id << "tunnel tw kqueue returned ok:" << rc
+                << std::endl;
+#endif
+            from_ready = false;
+            to_ready = false;
+            for (int i = 0; i < rc; ++i) {
+                if (events[i].ident == (uintptr_t)fdfrom)
+                    from_ready = true;
+                else if (events[i].ident == (uintptr_t)fdto)
+                    to_ready = true;
+            }
+        }
+
+        if (from_ready) {
+            int rc;
+            if (targetthroughput > -1)
+                rc = sockfrom.readFromSocket(buff, (((int)sizeof(buff) < ((targetthroughput - throughput))) ? sizeof(buff) : (int)(targetthroughput - throughput)), 0, 0, false);
+            else
+                rc = sockfrom.readFromSocket(buff, sizeof(buff), 0, 0, false);
+
+            if (rc < 0) {
+                break;
+            } else if (!rc) {
+                done = true;
+            } else {
+#ifdef DGDEBUG
+                std::cout <<thread_id << "tunnel got data from sockfrom: " << rc << " bytes" << std::endl;
+#endif
+                throughput += rc;
+                struct kevent wchange;
+                struct kevent wevent;
+                struct timespec tsw;
+                tsw.tv_sec = timeout / 1000;
+                tsw.tv_nsec = (timeout % 1000) * 1000000;
+                EV_SET(&wchange, fdto, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
+                if (kevent(kq, &wchange, 1, &wevent, 1, &tsw) < 1)
+                    break;
+                if ((wevent.flags & (EV_ERROR | EV_EOF)) || wevent.filter != EVFILT_WRITE)
+                    break;
+                if (!sockto.writeToSocket(buff, rc, 0, 0, false))
+                    break;
+#ifdef DGDEBUG
+                std::cout <<thread_id << "tunnel wrote data out: " << rc << " bytes" << std::endl;
+#endif
+                done = false;
+            }
+        }
+
+        if (to_ready) {
+            if (!twoway) {
+#ifdef DGDEBUG
+                std::cout <<thread_id << "fdto is sending data; closing tunnel. (This must be a persistent connection.)" << std::endl;
+#endif
+                break;
+            }
+            int rc = sockto.readFromSocket(buff, sizeof(buff), 0, 0, false);
+            if (rc < 0) {
+                break;
+            } else if (!rc) {
+                done = true;
+                break;
+            } else {
+                struct kevent wchange;
+                struct kevent wevent;
+                struct timespec tsw;
+                tsw.tv_sec = timeout / 1000;
+                tsw.tv_nsec = (timeout % 1000) * 1000000;
+                EV_SET(&wchange, fdfrom, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
+                if (kevent(kq, &wchange, 1, &wevent, 1, &tsw) < 1)
+                    break;
+                if ((wevent.flags & (EV_ERROR | EV_EOF)) || wevent.filter != EVFILT_WRITE)
+                    break;
+                if (!sockfrom.writeToSocket(buff, rc, 0, 0, false))
+                    break;
+                done = false;
+            }
+        }
+    }
+    close(kq);
+#else
     while (!done && (targetthroughput > -1 ? throughput < targetthroughput : true)) {
         done = true; // if we don't make a sucessful read and write this
         // flag will stay true and so the while() will exit
@@ -230,6 +363,7 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
                 }
             }
         }
+#endif
 #ifdef DGDEBUG
         if ((throughput >= targetthroughput) && (targetthroughput > -1))
             std::cout <<thread_id << "All expected data tunnelled. (expected " << targetthroughput << "; tunnelled " << throughput << ")" << std::endl;


### PR DESCRIPTION
## Summary
- Support FreeBSD by conditionally including `<sys/event.h>`
- Use kqueue/kevent for socket readiness checks on FreeBSD
- Add kqueue-based event loop for tunnelling when building on FreeBSD

## Testing
- `g++ -std=c++11 -c src/BaseSocket.cpp -Isrc`
- `g++ -std=c++11 -c src/FDTunnel.cpp -Isrc` *(fails: ‘String::String(off_t)’ cannot be overloaded with ‘String::String(long int)’)*

------
https://chatgpt.com/codex/tasks/task_e_689ea92f7f60832e9e8d204069532cc0