### PR TITLE
Avoid SIGPIPE on FreeBSD

### DIFF
--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -679,7 +679,12 @@ bool BaseSocket::writeToSocket(const char *buff, int len, unsigned int flags, in
         sent = 0;
         s_errno = 0;
         errno = 0;
-        if(!isNoWrite()) sent = send(sck, buff + actuallysent, len - actuallysent, 0);
+#ifdef MSG_NOSIGNAL
+        unsigned int send_flags = flags | MSG_NOSIGNAL;
+#else
+        unsigned int send_flags = flags;
+#endif
+        if(!isNoWrite()) sent = send(sck, buff + actuallysent, len - actuallysent, send_flags);
 
 //        if (sent == 0)
         if (sent  < 1)

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -247,6 +247,7 @@ int Socket::bind(int port) {
     setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i));
 #ifdef __FreeBSD__
     setsockopt(sck, SOL_SOCKET, SO_REUSEPORT, &i, sizeof(i));
+    setsockopt(sck, SOL_SOCKET, SO_NOSIGPIPE, &i, sizeof(i));
 #endif
 
     my_adr.sin_port = htons(port);
@@ -263,6 +264,7 @@ int Socket::bind(const std::string &ip, int port) {
     setsockopt(sck, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i));
 #ifdef __FreeBSD__
     setsockopt(sck, SOL_SOCKET, SO_REUSEPORT, &i, sizeof(i));
+    setsockopt(sck, SOL_SOCKET, SO_NOSIGPIPE, &i, sizeof(i));
 #endif
 
     my_adr.sin_port = htons(port);


### PR DESCRIPTION
## Summary
- add SO_NOSIGPIPE when binding sockets on FreeBSD
- send with MSG_NOSIGNAL to suppress SIGPIPE

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `./autogen.sh` *(fails: aclocal: not found)*
- `g++ -std=c++11 -c src/Socket.cpp -Isrc` *(fails: String::String(off_t) cannot be overloaded)*


------
https://chatgpt.com/codex/tasks/task_e_689eaa8c79c0832ebe5478326cf1bc17