### PR TITLE
Use clock_gettime for monotonic timing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ AC_TYPE_UID_T
 
 # Checks for library functions.
 AC_FUNC_FORK
-AC_CHECK_FUNCS([dup2 gettimeofday memset select])
+AC_CHECK_FUNCS([dup2 clock_gettime memset select])
 AC_CHECK_FUNCS([strerror strstr strtol])
 AC_CHECK_FUNCS([setuid setgid umask seteuid setreuid setlocale])
 AC_SEARCH_LIBS([floor], [m])

--- a/src/BackedStore.cpp
+++ b/src/BackedStore.cpp
@@ -23,7 +23,7 @@
 
 #include <sys/stat.h>
 #include <sys/mman.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include "BackedStore.hpp"
 
@@ -209,12 +209,12 @@ std::string BackedStore::store(const char *prefix)
         // Try creating a hardlink with the new name and see what happens
         std::ostringstream storedname;
         storedname << prefix;
-        timeval tv;
-        // Use time of day (in microsecond resolution) to try and generate
+        struct timespec ts;
+        // Use monotonic clock time (in nanosecond resolution) to try and generate
         // a "random" name for the hardlink - tempnam doesn't allow arbitrary
         // prefixes (POSIX says up to 5 chars).
-        gettimeofday(&tv, NULL);
-        storedname << '-' << tv.tv_sec << tv.tv_usec << std::flush;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        storedname << '-' << ts.tv_sec << ts.tv_nsec << std::flush;
 
         char *name = strrchr(filename, '/');
 #ifdef DGDEBUG

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -32,7 +32,7 @@
 #include <netdb.h>
 #include <cstdlib>
 #include <unistd.h>
-#include <sys/time.h>
+#include <time.h>
 #include <strings.h>
 #include <fcntl.h>
 #include <string.h>
@@ -651,8 +651,8 @@ int ConnectionHandler::handlePeer(Socket &peerconn, String &ip, stat_rec *&dysta
 
 int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismitm, Socket &proxysock,
                                         stat_rec *&dystat) {
-    struct timeval thestart;
-    gettimeofday(&thestart, NULL);
+    struct timespec thestart;
+    clock_gettime(CLOCK_MONOTONIC, &thestart);
 
     //peerconn.setTimeout(o.proxy_timeout);
     peerconn.setTimeout(o.pcon_timeout);
@@ -772,7 +772,7 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
             if (firsttime) {
                 // reset flags & objects next time round the loop
                 firsttime = false;
-                gettimeofday(&thestart, NULL);
+                clock_gettime(CLOCK_MONOTONIC, &thestart);
                 checkme.thestart = thestart;
 
                 // quick trick for the very first connection :-)
@@ -795,7 +795,7 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
                 ++dystat->reqs;
 
                 // we will actually need to do *lots* of resetting of flags etc. here for pconns to work
-                gettimeofday(&thestart, NULL);
+                clock_gettime(CLOCK_MONOTONIC, &thestart);
                 checkme.thestart = thestart;
 
                 checkme.bypasstimestamp = 0;
@@ -1502,7 +1502,7 @@ void ConnectionHandler::doLog(std::string &who, std::string &from, NaughtyFilter
     int naughtytype = cm.blocktype;
     bool isexception = cm.isexception;
     bool istext = cm.is_text;
-    struct timeval *thestart = &cm.thestart;
+    struct timespec *thestart = &cm.thestart;
     bool cachehit = false;
     //int code = (cm.wasrequested ? cm.response_header->returnCode() : 200);  //cm.wasrequested is never set anywhere!!
     int code = (cm.response_header->returnCode());
@@ -1624,7 +1624,7 @@ void ConnectionHandler::doLog(std::string &who, std::string &from, NaughtyFilter
         data += String(cachehit) + cr;
         data += String(mimetype) + cr;
         data += String((*thestart).tv_sec) + cr;
-        data += String((*thestart).tv_usec) + cr;
+        data += String((*thestart).tv_nsec) + cr;
         data += l_clienthost + cr;
         if (o.log_user_agent)
             data += (reqheader ? reqheader->userAgent() + cr : cr);
@@ -1665,7 +1665,7 @@ void ConnectionHandler::doRQLog(std::string &who, std::string &from, NaughtyFilt
     int naughtytype = cm.blocktype;
     bool isexception = cm.isexception;
     bool istext = cm.is_text;
-    struct timeval *thestart = &cm.thestart;
+    struct timespec *thestart = &cm.thestart;
     bool cachehit = false;
     int code = 0;
     std::string mimetype = cm.mimetype;
@@ -1733,7 +1733,7 @@ void ConnectionHandler::doRQLog(std::string &who, std::string &from, NaughtyFilt
         data += String(cachehit) + cr;
         data += String(mimetype) + cr;
         data += String((*thestart).tv_sec) + cr;
-        data += String((*thestart).tv_usec) + cr;
+        data += String((*thestart).tv_nsec) + cr;
         data += l_clienthost + cr;
         if (o.log_user_agent)
             data += (reqheader ? reqheader->userAgent() + cr : cr);
@@ -3244,8 +3244,8 @@ void ConnectionHandler::check_content(NaughtyFilter &cm, DataBuffer &docbody, So
 
 #ifdef __SSLMITM
 int ConnectionHandler::handleTHTTPSConnection(Socket &peerconn, String &ip, Socket &proxysock, stat_rec* &dystat) {
-    struct timeval thestart;
-    gettimeofday(&thestart, NULL);
+    struct timespec thestart;
+    clock_gettime(CLOCK_MONOTONIC, &thestart);
 
     peerconn.setTimeout(o.pcon_timeout);
 
@@ -3386,7 +3386,7 @@ std::cerr << thread_id << " -got peer connection - clientip is " << clientip << 
             // do all of this normalisation etc just the once at the start.
             checkme.url = "https://" + checkme.url;
             checkme.setURL(checkme.url);
-            gettimeofday(&checkme.thestart, NULL);
+            clock_gettime(CLOCK_MONOTONIC, &checkme.thestart);
 
 
             // Look up reverse DNS name of client if needed
@@ -3638,8 +3638,8 @@ int ConnectionHandler::handleICAPConnection(Socket &peerconn, String &ip, Socket
     int pcount = 0;
     bool ismitm = false;
 
-    struct timeval thestart;
-    gettimeofday(&thestart, NULL);
+    struct timespec thestart;
+    clock_gettime(CLOCK_MONOTONIC, &thestart);
 
     peerconn.setTimeout(o.pcon_timeout);
 
@@ -3684,7 +3684,7 @@ int ConnectionHandler::handleICAPConnection(Socket &peerconn, String &ip, Socket
             if (firsttime) {
                 // reset flags & objects next time round the loop
                 firsttime = false;
-                gettimeofday(&thestart, NULL);
+                clock_gettime(CLOCK_MONOTONIC, &thestart);
                 checkme.thestart = thestart;
             }
 
@@ -3739,7 +3739,7 @@ int ConnectionHandler::handleICAPConnection(Socket &peerconn, String &ip, Socket
                 ip = icaphead.clientip;
 
                 // we will actually need to do *lots* of resetting of flags etc. here for pconns to work
-                gettimeofday(&thestart, NULL);
+                clock_gettime(CLOCK_MONOTONIC, &thestart);
                 checkme.thestart = thestart;
 
                 //authed = false;

--- a/src/DataBuffer.cpp
+++ b/src/DataBuffer.cpp
@@ -19,7 +19,7 @@
 #include <zlib.h>
 #include <cerrno>
 #include <fstream>
-#include <sys/time.h>
+#include <time.h>
 #include <queue>
 #include <istream>
 
@@ -139,9 +139,9 @@ int DataBuffer::bufferReadFromSocket(Socket *sock, char *buffer, int size, int s
 
     int pos = 0;
     int rc;
-    struct timeval starttime;
-    struct timeval nowadays;
-    gettimeofday(&starttime, NULL);
+    struct timespec starttime;
+    struct timespec nowadays;
+    clock_gettime(CLOCK_MONOTONIC, &starttime);
     while (pos < size) {
         if (chunked) {
             rc = sock->readChunk(&buffer[pos], size - pos,sockettimeout );
@@ -156,8 +156,10 @@ int DataBuffer::bufferReadFromSocket(Socket *sock, char *buffer, int size, int s
             return rc; // just return with the return code
         }
         pos += rc;
-        gettimeofday(&nowadays, NULL);
-        if (nowadays.tv_sec - starttime.tv_sec > stimeout) {
+        clock_gettime(CLOCK_MONOTONIC, &nowadays);
+        long long diff_ns = (nowadays.tv_sec - starttime.tv_sec) * 1000000000LL +
+                            (nowadays.tv_nsec - starttime.tv_nsec);
+        if (diff_ns > (long long)stimeout * 1000000000LL) {
 #ifdef DGDEBUG
             std::cerr << thread_id << "buffered socket read more than timeout" << std::endl;
 #endif

--- a/src/FatController.cpp
+++ b/src/FatController.cpp
@@ -12,6 +12,7 @@
 #include <syslog.h>
 #include <csignal>
 #include <ctime>
+#include <time.h>
 #include <sys/stat.h>
 #include <pwd.h>
 #include <cerrno>
@@ -690,7 +691,7 @@ void log_listener(std::string log_location, bool logconerror, bool logsyslog, Qu
     std::string stype, postdata;
     int port = 80, isnaughty = 0, isexception = 0, code = 200, naughtytype = 0;
     int cachehit = 0, wasinfected = 0, wasscanned = 0, filtergroup = 0;
-    long tv_sec = 0, tv_usec = 0;
+    long tv_sec = 0, tv_nsec = 0;
     int contentmodified = 0, urlmodified = 0, headermodified = 0;
     int headeradded = 0;
 
@@ -837,7 +838,7 @@ void log_listener(std::string log_location, bool logconerror, bool logsyslog, Qu
                     tv_sec = atol(logline.c_str());
                     break;
                 case 22:
-                    tv_usec = atol(logline.c_str());
+                    tv_nsec = atol(logline.c_str());
                     break;
                 case 23:
                     clienthost = s;
@@ -937,13 +938,13 @@ void log_listener(std::string log_location, bool logconerror, bool logsyslog, Qu
         }
 
         std::string builtline, year, month, day, hour, min, sec, when, vbody, utime;
-        struct timeval theend;
+        struct timespec theend;
 
         // create a string representation of UNIX timestamp if desired
         if (o.log_timestamp || (o.log_file_format == 3)
             || (o.log_file_format > 4)) {
-            gettimeofday(&theend, NULL);
-            String temp((int) (theend.tv_usec / 1000));
+            clock_gettime(CLOCK_MONOTONIC, &theend);
+            String temp((int) (theend.tv_nsec / 1000000));
             while (temp.length() < 3) {
                 temp = "0" + temp;
             }
@@ -1001,11 +1002,10 @@ void log_listener(std::string log_location, bool logconerror, bool logsyslog, Qu
             case 3: {
                 // as certain bits of info are logged in format 3, their creation is best done here, not in all cases.
                 std::string duration, hier, hitmiss;
-                long durationsecs, durationusecs;
-                durationsecs = (theend.tv_sec - tv_sec);
-                durationusecs = theend.tv_usec - tv_usec;
-                durationusecs = (durationusecs / 1000) + durationsecs * 1000;
-                String temp((int) durationusecs);
+                long long durationnsecs = (theend.tv_sec - tv_sec) * 1000000000LL +
+                                          (theend.tv_nsec - tv_nsec);
+                long durationmsecs = durationnsecs / 1000000;
+                String temp((int) durationmsecs);
                 while (temp.length() < 6) {
                     temp = " " + temp;
                 }
@@ -1049,11 +1049,10 @@ void log_listener(std::string log_location, bool logconerror, bool logsyslog, Qu
             case 6:
             default:
                 std::string duration;
-                long durationsecs, durationusecs;
-                durationsecs = (theend.tv_sec - tv_sec);
-                durationusecs = theend.tv_usec - tv_usec;
-                durationusecs = (durationusecs / 1000) + durationsecs * 1000;
-                String temp((int) durationusecs);
+                long long durationnsecs = (theend.tv_sec - tv_sec) * 1000000000LL +
+                                          (theend.tv_nsec - tv_nsec);
+                long durationmsecs = durationnsecs / 1000000;
+                String temp((int) durationmsecs);
                 duration = temp;
 
                 builtline = utime + "\t"

--- a/src/NaughtyFilter.hpp
+++ b/src/NaughtyFilter.hpp
@@ -14,6 +14,8 @@
 //#include "FOptionContainer.hpp"
 #include "UrlRec.hpp"
 
+#include <time.h>
+
 class FOptionContainer;
 
 // DECLARATIONS        bool isListCheck = false;
@@ -105,7 +107,7 @@ class NaughtyFilter
     int auth_result = 0;
     String search_words;
     String search_terms;
-    struct timeval thestart;
+    struct timespec thestart;
 
     // 0=none,1=first line,2=all
     int headersent = 0;

--- a/src/downloadmanagers/default.cpp
+++ b/src/downloadmanagers/default.cpp
@@ -14,7 +14,7 @@
 
 #include <string.h>
 #include <syslog.h>
-#include <sys/time.h>
+#include <time.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -112,9 +112,9 @@ int dminstance::in(DataBuffer *d, Socket *sock, Socket *peersock, class HTTPHead
     bool swappedtodisk = false;
     bool doneinitialdelay = false;
 
-    struct timeval themdays;
-    struct timeval nowadays;
-    gettimeofday(&themdays, NULL);
+    struct timespec themdays;
+    struct timespec nowadays;
+    clock_gettime(CLOCK_MONOTONIC, &themdays);
 
     // buffer size for streaming downloads
     off_t blocksize = 32768;
@@ -130,10 +130,12 @@ int dminstance::in(DataBuffer *d, Socket *sock, Socket *peersock, class HTTPHead
     while ((bytesremaining > 0) || geteverything) {
         // send x-header keep-alive here
         if (o.trickle_delay > 0) {
-            gettimeofday(&nowadays, NULL);
-            if (doneinitialdelay ? nowadays.tv_sec - themdays.tv_sec > o.trickle_delay :
-                nowadays.tv_sec - themdays.tv_sec > o.initial_trickle_delay) {
-                themdays.tv_sec = nowadays.tv_sec;
+            clock_gettime(CLOCK_MONOTONIC, &nowadays);
+            long long diff_ns = (nowadays.tv_sec - themdays.tv_sec) * 1000000000LL +
+                                (nowadays.tv_nsec - themdays.tv_nsec);
+            long long limit_ns = (long long)(doneinitialdelay ? o.trickle_delay : o.initial_trickle_delay) * 1000000000LL;
+            if (diff_ns > limit_ns) {
+                themdays = nowadays;
                 doneinitialdelay = true;
                 if ((*headersent) < 1) {
 #ifdef DGDEBUG

--- a/src/downloadmanagers/fancy.cpp
+++ b/src/downloadmanagers/fancy.cpp
@@ -14,7 +14,7 @@
 
 #include <string.h>
 #include <syslog.h>
-#include <sys/time.h>
+#include <time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <iostream>
@@ -174,11 +174,11 @@ int fancydm::in(DataBuffer *d, Socket *sock, Socket *peersock, class HTTPHeader 
 
     bool swappedtodisk = false;
 
-    struct timeval starttime;
-    struct timeval themdays;
-    struct timeval nowadays;
-    gettimeofday(&themdays, NULL);
-    gettimeofday(&starttime, NULL);
+    struct timespec starttime;
+    struct timespec themdays;
+    struct timespec nowadays;
+    clock_gettime(CLOCK_MONOTONIC, &themdays);
+    clock_gettime(CLOCK_MONOTONIC, &starttime);
 
     toobig_unscanned = false;
     toobig_notdownloaded = false;
@@ -209,12 +209,17 @@ int fancydm::in(DataBuffer *d, Socket *sock, Socket *peersock, class HTTPHeader 
     while ((bytesgot < expectedsize) || geteverything) {
         // send text header to show status
         if (o.trickle_delay > 0) {
-            gettimeofday(&nowadays, NULL);
-            timeelapsed = nowadays.tv_sec - starttime.tv_sec;
-            if ((!initialsent && timeelapsed > o.initial_trickle_delay) || (initialsent && nowadays.tv_sec - themdays.tv_sec > o.trickle_delay)) {
+            clock_gettime(CLOCK_MONOTONIC, &nowadays);
+            long long timeelapsed_ns = (nowadays.tv_sec - starttime.tv_sec) * 1000000000LL +
+                                      (nowadays.tv_nsec - starttime.tv_nsec);
+            timeelapsed = timeelapsed_ns / 1000000000;
+            long long diff_ns = (nowadays.tv_sec - themdays.tv_sec) * 1000000000LL +
+                                (nowadays.tv_nsec - themdays.tv_nsec);
+            if ((!initialsent && timeelapsed_ns > (long long)o.initial_trickle_delay * 1000000000LL) ||
+                (initialsent && diff_ns > (long long)o.trickle_delay * 1000000000LL)) {
                 initialsent = true;
-                bytessec = bytesgot / timeelapsed;
-                themdays.tv_sec = nowadays.tv_sec;
+                bytessec = timeelapsed > 0 ? bytesgot / timeelapsed : 0;
+                themdays = nowadays;
                 if ((*headersent) < 1) {
 #ifdef DGDEBUG
                     std::cout << "sending header for text status" << std::endl;

--- a/src/downloadmanagers/trickle.cpp
+++ b/src/downloadmanagers/trickle.cpp
@@ -19,7 +19,7 @@
 
 #include <string.h>
 #include <syslog.h>
-#include <sys/time.h>
+#include <time.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -109,9 +109,9 @@ int trickledm::in(DataBuffer *d, Socket *sock, Socket *peersock, class HTTPHeade
     bool swappedtodisk = false;
     bool doneinitialdelay = false;
 
-    struct timeval themdays;
-    struct timeval nowadays;
-    gettimeofday(&themdays, NULL);
+    struct timespec themdays;
+    struct timespec nowadays;
+    clock_gettime(CLOCK_MONOTONIC, &themdays);
 
     // buffer size for streaming downloads
     off_t blocksize = 32768;
@@ -127,9 +127,13 @@ int trickledm::in(DataBuffer *d, Socket *sock, Socket *peersock, class HTTPHeade
     while ((bytesremaining > 0) || geteverything) {
         // send keep-alive bytes here
         if (o.trickle_delay > 0) {
-            gettimeofday(&nowadays, NULL);
-            if (doneinitialdelay ? nowadays.tv_sec - themdays.tv_sec > o.trickle_delay : nowadays.tv_sec > o.initial_trickle_delay) {
-                themdays.tv_sec = nowadays.tv_sec;
+            clock_gettime(CLOCK_MONOTONIC, &nowadays);
+            long long diff_ns = (nowadays.tv_sec - themdays.tv_sec) * 1000000000LL +
+                                (nowadays.tv_nsec - themdays.tv_nsec);
+            long long now_ns = nowadays.tv_sec * 1000000000LL + nowadays.tv_nsec;
+            if (doneinitialdelay ? diff_ns > (long long)o.trickle_delay * 1000000000LL :
+                                   now_ns > (long long)o.initial_trickle_delay * 1000000000LL) {
+                themdays = nowadays;
                 doneinitialdelay = true;
                 if ((*headersent) < 1) {
 #ifdef DGDEBUG


### PR DESCRIPTION
## Summary
- replace gettimeofday calls with clock_gettime and struct timespec
- compute time differences in nanoseconds across data buffering, logging, and download managers
- add build check for clock_gettime

## Testing
- `autoreconf -i` *(fails: Can't exec "aclocal": No such file or directory)*
- `./configure` *(fails: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689ead0188dc832eb6e26d3c476bd8d6