### PR TITLE
Add optional FreeBSD httpready accept filter

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -176,11 +176,17 @@ mapportstoips = off
 transparenthttpsport = 8443
 
 #port for ICAP
-#if defined enables icap mode 
-#icapport = 1344  
+#if defined enables icap mode
+#icapport = 1344
+
+# Use FreeBSD's httpready accept filter on listening sockets.
+# Requires the accf_http kernel module.  Disable if the module is
+# unavailable.
+# on | off
+usehttpreadyacceptfilter = off
 
 # the ip of upstream proxy - optional - if blank e2g will go direct to sites.
-# default is "" i.e. no proxy 
+# default is "" i.e. no proxy
 #proxyip = 127.0.0.1
 
 # the port e2guardian connects to proxy on

--- a/doc/e2guardian.8
+++ b/doc/e2guardian.8
@@ -24,6 +24,14 @@ information such as every image on a page.
 
 e2guardian is under continuous development and so it is best to visit the web site for the latest information.
 
+.PP
+On FreeBSD systems e2guardian can optionally use the kernel's
+httpready accept filter to delay handing connections to workers until
+an HTTP request is present. This feature is controlled by the
+\fBusehttpreadyacceptfilter\fR configuration option and requires the
+\fBaccf_http\fR module; disable the option if the module is not
+available.
+
  (1) Technically e2guardian is more of a filtering pass\-through than a true proxy \- but don't let that worry you!
 
  (2) e2guardian should work with any proxy, not just Squid. For example, it is known to work with Oops.

--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -21,6 +21,7 @@
 #include <sys/select.h>
 #ifdef __FreeBSD__
 #include <sys/event.h>
+#include <netinet/accept_filter.h>
 #endif
 
 #ifdef NETDEBUG
@@ -28,10 +29,12 @@
 #endif
 
 #include "BaseSocket.hpp"
+#include "OptionContainer.hpp"
 
 // GLOBALS
 extern bool reloadconfig;
 extern thread_local std::string thread_id;
+extern OptionContainer o;
 
 // DEFINITIONS
 
@@ -113,7 +116,18 @@ void BaseSocket::baseReset()
 // mark a socket as a listening server socket
 int BaseSocket::listen(int queue)
 {
-    return ::listen(sck, queue);
+    int ret = ::listen(sck, queue);
+#ifdef __FreeBSD__
+    if (ret == 0 && o.use_httpready_accept_filter) {
+        struct accept_filter_arg af;
+        memset(&af, 0, sizeof(af));
+        strcpy(af.af_name, "httpready");
+        if (setsockopt(sck, SOL_SOCKET, SO_ACCEPTFILTER, &af, sizeof(af)) < 0) {
+            syslog(LOG_ERR, "%sFailed to set accept filter: %s", thread_id.c_str(), strerror(errno));
+        }
+    }
+#endif
+    return ret;
 }
 
 // "template adaptor" for accept - basically, let G++ do the hard work of

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -628,6 +628,12 @@ bool OptionContainer::read(std::string& filename, int type)
         if (icap_resmod_url == "")
             icap_resmod_url = "response";
 
+        if (findoptionS("usehttpreadyacceptfilter") == "on") {
+            use_httpready_accept_filter = true;
+        } else {
+            use_httpready_accept_filter = false;
+        }
+
 #ifdef ENABLE_ORIG_IP
         if (findoptionS("originalip") == "on") {
             get_orig_ip = true;

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -87,6 +87,7 @@ class OptionContainer
     int icap_port = 0;
     std::string icap_reqmod_url;
     std::string icap_resmod_url;
+    bool use_httpready_accept_filter = false;
     std::string proxy_ip;
     std::deque<String> filter_ip;
     std::deque<String> check_ip;


### PR DESCRIPTION
## Summary
- Add optional FreeBSD `httpready` accept filter with new `usehttpreadyacceptfilter` config toggle
- Document the new option in the manual and default configuration file

## Testing
- `./autogen.sh` *(fails: aclocal not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689eb03c394c832e93721b142ceb2eb2