### PR TITLE
Update version references to 5.3.8

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,8 @@
 About "Bug" tags show "https://github.com/e2guardian/e2guardian/issues?q=is%3Aissue+is%3Aclosed" 
 
-version 5.3.5
+version 5.3.8
 
-February 2020 to August 2020
+February 2020 to August 2020 (updates through 5.3.8)
 
 - Fix bug #619 x-forwarded wrong IP in MITM requests
 - Fix #607 - exceptionmimetypes not working

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_DEFINE([__SSLMITM],[""],[Define to enable SSL MITM])
 AC_DEFINE([FD_SETSIZE_OVERIDE],[""],[Define to allow DANS_MAXFD to exceed FD_SETSIZE])
 
 AC_PREREQ(2.57)
-AC_INIT(e2guardian, 5.3.5)
+AC_INIT(e2guardian, 5.3.8)
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADERS([dgconfig.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/notes/NEWIN_v5
+++ b/notes/NEWIN_v5
@@ -1,4 +1,4 @@
-This is the v5.3.5 stable version
+This is the v5.3.8 stable version
 
 Note that large sections of the code has been re-written and there are
 significant changes to the configuration files in v5.


### PR DESCRIPTION
## Summary
- update configure.ac to advertise e2guardian 5.3.8
- refresh ChangeLog header to reference version 5.3.8
- align NEWIN_v5 notes with the new stable version designation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8136a46c832eaf2ae1c09e3f3061