### PR TITLE
Guard HTTP ready accept filter behind header detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,7 @@ AC_CHECK_HEADERS([string.h sys/socket.h sys/time.h syslog.h unistd.h locale.h])
 AC_CHECK_HEADERS([sys/types.h sys/un.h sys/poll.h sys/epoll.h sys/resource.h])
 AC_CHECK_HEADERS([pwd.h grp.h])
 AC_CHECK_HEADERS([byteswap.h])
+AC_CHECK_HEADERS([netinet/accept_filter.h])
 
 # Check system endianness
 AC_C_BIGENDIAN

--- a/dgconfig.h.in
+++ b/dgconfig.h.in
@@ -1,0 +1,262 @@
+/* dgconfig.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
+/* Define to enable debug build mode */
+#undef DGDEBUG
+
+/* Record configure-time options */
+#undef DG_CONFIGURE_OPTIONS
+
+/* Define to enable AvastD content scanner */
+#undef ENABLE_AVASTD
+
+/* Define to enable ClamD content scanner */
+#undef ENABLE_CLAMD
+
+/* Define to enable command-line content scanner */
+#undef ENABLE_COMMANDLINE
+
+/* Define to enable email reporting */
+#undef ENABLE_EMAIL
+
+/* Define to enable ICAP content scanner */
+#undef ENABLE_ICAP
+
+/* Define to enable KAVD content scanner */
+#undef ENABLE_KAVD
+
+/* Define to enable NTLM auth plugin */
+#undef ENABLE_NTLM
+
+/* Define to enable original destination IP checking */
+#undef ENABLE_ORIG_IP
+
+/* Define to allow DANS_MAXFD to exceed FD_SETSIZE */
+#undef FD_SETSIZE_OVERIDE
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#undef HAVE_ARPA_INET_H
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#undef HAVE_BYTESWAP_H
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#undef HAVE_CLOCK_GETTIME
+
+/* Define to 1 if you have the `dup2' function. */
+#undef HAVE_DUP2
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#undef HAVE_FCNTL_H
+
+/* Define to 1 if you have the `fork' function. */
+#undef HAVE_FORK
+
+/* Define to 1 if you have the <grp.h> header file. */
+#undef HAVE_GRP_H
+
+/* Define to 1 if you have the `iconv' function. */
+#undef HAVE_ICONV
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <limits.h> header file. */
+#undef HAVE_LIMITS_H
+
+/* Define to 1 if you have the <locale.h> header file. */
+#undef HAVE_LOCALE_H
+
+/* Define to 1 if you have the `memset' function. */
+#undef HAVE_MEMSET
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#undef HAVE_NETDB_H
+
+/* Define to 1 if you have the <netinet/accept_filter.h> header file. */
+#undef HAVE_NETINET_ACCEPT_FILTER_H
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#undef HAVE_NETINET_IN_H
+
+/* Define to enable PCRE support */
+#undef HAVE_PCRE
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#undef HAVE_PTHREAD_H
+
+/* Define to 1 if you have the <pwd.h> header file. */
+#undef HAVE_PWD_H
+
+/* Define to 1 if you have the `regcomp' function. */
+#undef HAVE_REGCOMP
+
+/* Define to 1 if you have the `select' function. */
+#undef HAVE_SELECT
+
+/* Define to 1 if you have the `seteuid' function. */
+#undef HAVE_SETEUID
+
+/* Define to 1 if you have the `setgid' function. */
+#undef HAVE_SETGID
+
+/* Define to 1 if you have the `setlocale' function. */
+#undef HAVE_SETLOCALE
+
+/* Define to 1 if you have the `setreuid' function. */
+#undef HAVE_SETREUID
+
+/* Define to 1 if you have the `setuid' function. */
+#undef HAVE_SETUID
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#undef HAVE_STDIO_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the `strerror' function. */
+#undef HAVE_STRERROR
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the `strstr' function. */
+#undef HAVE_STRSTR
+
+/* Define to 1 if you have the `strtol' function. */
+#undef HAVE_STRTOL
+
+/* Define to 1 if you have the <syslog.h> header file. */
+#undef HAVE_SYSLOG_H
+
+/* Define to 1 if you have the <sys/epoll.h> header file. */
+#undef HAVE_SYS_EPOLL_H
+
+/* Define to 1 if you have the <sys/poll.h> header file. */
+#undef HAVE_SYS_POLL_H
+
+/* Define to 1 if you have the <sys/resource.h> header file. */
+#undef HAVE_SYS_RESOURCE_H
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#undef HAVE_SYS_SOCKET_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#undef HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <sys/un.h> header file. */
+#undef HAVE_SYS_UN_H
+
+/* Define to 1 if you have the `umask' function. */
+#undef HAVE_UMASK
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Define to 1 if you have the `vfork' function. */
+#undef HAVE_VFORK
+
+/* Define to 1 if you have the <vfork.h> header file. */
+#undef HAVE_VFORK_H
+
+/* Define to 1 if `fork' works. */
+#undef HAVE_WORKING_FORK
+
+/* Define to 1 if `vfork' works. */
+#undef HAVE_WORKING_VFORK
+
+/* Define to 1 if you have the <zlib.h> header file. */
+#undef HAVE_ZLIB_H
+
+/* Define to enable debug build mode for socket functions */
+#undef NETDEBUG
+
+/* Define to disable debuglevel build mode */
+#undef NEWDEBUG_OFF
+
+/* Define to enable debuglevel build mode */
+#undef NEWDEBUG_ON
+
+/* Define if type "off_t" is a typedef of another type for which String
+   already has a constructor */
+#undef OFFT_COLLISION
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to enable DNS auth plugin */
+#undef PRT_DNSAUTH
+
+/* Define to enable debug build mode for regexp functions */
+#undef REDEBUG
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#undef STDC_HEADERS
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
+
+/* Define to enable SSL CERT */
+#undef __SSLCERT
+
+/* Define to enable SSL MITM */
+#undef __SSLMITM
+
+/* Define to `int' if <sys/types.h> doesn't define. */
+#undef gid_t
+
+/* Define to `long int' if <sys/types.h> does not define. */
+#undef off_t
+
+/* Define as a signed integer type capable of holding a process identifier. */
+#undef pid_t
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#undef size_t
+
+/* Define to `int' if <sys/types.h> doesn't define. */
+#undef uid_t
+
+/* Define as `fork' if `vfork' does not work. */
+#undef vfork

--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -21,6 +21,8 @@
 #include <sys/select.h>
 #ifdef __FreeBSD__
 #include <sys/event.h>
+#endif
+#ifdef HAVE_NETINET_ACCEPT_FILTER_H
 #include <netinet/accept_filter.h>
 #endif
 
@@ -117,7 +119,7 @@ void BaseSocket::baseReset()
 int BaseSocket::listen(int queue)
 {
     int ret = ::listen(sck, queue);
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) && defined(HAVE_NETINET_ACCEPT_FILTER_H)
     if (ret == 0 && o.use_httpready_accept_filter) {
         struct accept_filter_arg af;
         memset(&af, 0, sizeof(af));
@@ -125,6 +127,11 @@ int BaseSocket::listen(int queue)
         if (setsockopt(sck, SOL_SOCKET, SO_ACCEPTFILTER, &af, sizeof(af)) < 0) {
             syslog(LOG_ERR, "%sFailed to set accept filter: %s", thread_id.c_str(), strerror(errno));
         }
+    }
+#elif defined(__FreeBSD__)
+    if (ret == 0 && o.use_httpready_accept_filter) {
+        syslog(LOG_WARNING, "%sHTTP ready accept filter not supported by this build; disabling", thread_id.c_str());
+        o.use_httpready_accept_filter = false;
     }
 #endif
     return ret;

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -628,11 +628,21 @@ bool OptionContainer::read(std::string& filename, int type)
         if (icap_resmod_url == "")
             icap_resmod_url = "response";
 
+#ifdef HAVE_NETINET_ACCEPT_FILTER_H
         if (findoptionS("usehttpreadyacceptfilter") == "on") {
             use_httpready_accept_filter = true;
         } else {
             use_httpready_accept_filter = false;
         }
+#else
+        if (findoptionS("usehttpreadyacceptfilter") == "on") {
+            if (!is_daemonised) {
+                std::cerr << "usehttpreadyacceptfilter requested but not supported; disabling" << std::endl;
+            }
+            syslog(LOG_WARNING, "%s", "usehttpreadyacceptfilter requested but not supported; disabling");
+        }
+        use_httpready_accept_filter = false;
+#endif
 
 #ifdef ENABLE_ORIG_IP
         if (findoptionS("originalip") == "on") {


### PR DESCRIPTION
## Summary
- add a configure probe for netinet/accept_filter.h and regenerate dgconfig.h.in
- wrap BaseSocket accept-filter include and usage in HAVE_NETINET_ACCEPT_FILTER_H guards with a runtime fallback
- automatically disable the usehttpreadyacceptfilter option when support is unavailable

## Testing
- `autoreconf -fi` *(fails: aclocal missing because automake is unavailable and apt repositories return 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc936aae84832eb2b56635be19a4ac