### PR TITLE
Use global close for FreeBSD kqueue cleanup

### DIFF
--- a/src/BaseSocket.cpp
+++ b/src/BaseSocket.cpp
@@ -266,7 +266,7 @@ bool BaseSocket::bcheckSForInput(int timeout)
     ts.tv_sec = timeout / 1000;
     ts.tv_nsec = (timeout % 1000) * 1000000;
     rc = kevent(kq, &change, 1, &event, 1, &ts);
-    close(kq);
+    ::close(kq);
     if (rc == 0) {
         timedout = true;
         return false;
@@ -334,7 +334,7 @@ bool BaseSocket::bcheckForInput(int timeout)
     ts.tv_sec = timeout / 1000;
     ts.tv_nsec = (timeout % 1000) * 1000000;
     rc = kevent(kq, &change, 1, &event, 1, &ts);
-    close(kq);
+    ::close(kq);
     if (rc == 0) {
         timedout = true;
         return false;
@@ -402,7 +402,7 @@ bool BaseSocket::checkForInput()
     ts.tv_sec = 0;
     ts.tv_nsec = 0;
     rc = kevent(kq, &change, 1, &event, 1, &ts);
-    close(kq);
+    ::close(kq);
     if (rc == 0) {
         return false;
     }
@@ -468,7 +468,7 @@ bool BaseSocket::readyForOutput()
     ts.tv_sec = 0;
     ts.tv_nsec = 0;
     rc = kevent(kq, &change, 1, &event, 1, &ts);
-    close(kq);
+    ::close(kq);
     if (rc == 0) {
         return false;
     }
@@ -526,7 +526,7 @@ bool BaseSocket::breadyForOutput(int timeout) {
     ts.tv_sec = timeout / 1000;
     ts.tv_nsec = (timeout % 1000) * 1000000;
     rc = kevent(kq, &change, 1, &event, 1, &ts);
-    close(kq);
+    ::close(kq);
     if (rc == 0) {
         timedout = true;
         return false;


### PR DESCRIPTION
## Summary
- ensure FreeBSD kqueue cleanup paths explicitly invoke the global POSIX close

## Testing
- gmake *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc955aea84832e9dde2d1014bd3492