### PR TITLE
Adjust MITM certificate start defaults

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -668,13 +668,12 @@ generatedcertpath = '@DGCONFDIR@/private/generatedcerts/'
 #         store and also may get problems on running client browsers
 
 #Generated cert start time (in unix time) - optional
-# defaults to 1417872951 = 6th Dec 2014
-# generatedcertstart = 1417872951 
+# defaults to the current system time when certificates are generated
+# generatedcertstart = 1417872951
 
 #Generated cert end time (in unix time) - optional
 # defaults to generatedcertstart + 10 years
 #genratedcertend =
-# generatedcertstart =
 
 #Use openssl configuration file
 # switch this on if you want e2g to read in openssl configuration

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -18,6 +18,7 @@
 #include <syslog.h>
 #include <dirent.h>
 #include <cstdlib>
+#include <ctime>
 #include <unistd.h> // checkme: remove?
 
 // GLOBALS
@@ -280,11 +281,17 @@ bool OptionContainer::read(std::string& filename, int type)
         }
 
         time_t gen_cert_start, gen_cert_end;
-        time_t def_start = 1728164194; // Thu Oct 05 2024 21:36:34
-        time_t ten_years = 315532800;  // Thu Oct 05 2034 21:36:34
-        gen_cert_start = findoptionI("generatedcertstart");
-        if (gen_cert_start < def_start)
-            gen_cert_start = def_start;
+        time_t ten_years = 315532800;  // 10 years in seconds
+        std::string gen_cert_start_option = findoptionS("generatedcertstart");
+        if (!gen_cert_start_option.empty()) {
+            gen_cert_start = findoptionI("generatedcertstart");
+        } else {
+            time_t now = time(nullptr);
+            if (now < 0) {
+                now = 0;
+            }
+            gen_cert_start = now;
+        }
         gen_cert_end = findoptionI("generatedcertend");
         if (gen_cert_end < gen_cert_start)
             gen_cert_end = gen_cert_start + ten_years;


### PR DESCRIPTION
## Summary
- default the generated certificate start time to the configured value when present or the current time when unset, and keep the end date 10 years later
- update the configuration template comments to document the new default behaviour

## Testing
- ./testbuild/test_ca

------
https://chatgpt.com/codex/tasks/task_e_68cca454642c832ea86acc0c93c4fe16