### PR TITLE
Run garbage collection after list reloads

### DIFF
--- a/src/FatController.cpp
+++ b/src/FatController.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <vector>
 #include <atomic>
+#include <cstddef>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/select.h>
@@ -1720,9 +1721,17 @@ int fc_controlit()   //
             std::cerr << thread_id << "gentle reload activated" << std::endl;
 #endif
             syslog(LOG_INFO, "%sReconfiguring E2guardian: gentle reload starting", thread_id.c_str());
-            if (o.createLists(++reload_cnt))
-                syslog(LOG_INFO, "%sReconfiguring E2guardian: gentle reload completed", thread_id.c_str());
-            else
+            if (o.createLists(++reload_cnt)) {
+                // Garbage collection must follow every reload so unused lists do not accumulate indefinitely.
+                std::size_t reclaimed = o.lm.garbageCollect();
+                if (reclaimed > 0) {
+                    syslog(LOG_INFO,
+                           "%sReconfiguring E2guardian: gentle reload completed; reclaimed %zu unused lists",
+                           thread_id.c_str(), reclaimed);
+                } else {
+                    syslog(LOG_INFO, "%sReconfiguring E2guardian: gentle reload completed", thread_id.c_str());
+                }
+            } else
                 syslog(LOG_INFO, "%sReconfiguring E2guardian: gentle reload failed", thread_id.c_str());
 
             gentlereload = false;

--- a/src/ListManager.cpp
+++ b/src/ListManager.cpp
@@ -57,8 +57,9 @@ int ListManager::findNULL()
 }
 
 // delete all lists with zero reference count
-void ListManager::garbageCollect()
+std::size_t ListManager::garbageCollect()
 {
+    std::size_t reclaimed = 0;
     for (unsigned int i = 0; i < l.size(); i++) {
         if (l[i] != NULL) {
             if ((*l[i]).refcount < 1) {
@@ -67,9 +68,11 @@ void ListManager::garbageCollect()
 #endif
                 delete l[i];
                 l[i] = NULL;
+                ++reclaimed;
             }
         }
     }
+    return reclaimed;
 }
 
 void ListManager::deRefList(size_t i)

--- a/src/ListManager.hpp
+++ b/src/ListManager.hpp
@@ -12,6 +12,7 @@
 #include "String.hpp"
 #include "ListContainer.hpp"
 
+#include <cstddef>
 #include <deque>
 
 // DECLARATION
@@ -41,7 +42,7 @@ class ListManager
     void deRefList(size_t item);
 
     // delete lists with refcount zero
-    void garbageCollect();
+    std::size_t garbageCollect();
 
     private:
     // find an empty slot in our collection of listcontainters


### PR DESCRIPTION
## Summary
- invoke ListManager garbage collection after successful gentle reloads and log reclaimed list counts
- update ListManager::garbageCollect to report the number of freed lists for callers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e03cd63dc0832eba7d5798b4cab1d0