### PR TITLE
Fix IP auth plugin binary search bounds

### DIFF
--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -224,8 +224,8 @@ int ipinstance::determineGroup(std::string &user, int &rfg, ListContainer &uglc)
 // search for IP in list & return filter group on success, -1 on failure
 int ipinstance::inList(const uint32_t &ip)
 {
-    if (iplist.size() > 0) {
-        return searchList(0, iplist.size(), ip);
+    if (!iplist.empty()) {
+        return searchList(0, static_cast<int>(iplist.size()) - 1, ip);
     }
     return -1;
 }
@@ -235,6 +235,7 @@ int ipinstance::searchList(int a, int s, const uint32_t &ip)
 {
     if (a > s)
         return -1;
+
     int m = (a + s) / 2;
     if (iplist[m] == ip)
         return iplist[m].group;


### PR DESCRIPTION
## Summary
- fix the IP auth plugin's binary search to avoid indexing past the end of the address list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e2e98ea0832eb9059b4acfb4a98b