### PR TITLE
Bump release version to 5.3.8_2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 About "Bug" tags show "https://github.com/e2guardian/e2guardian/issues?q=is%3Aissue+is%3Aclosed"
 
-version 5.3.8
+version 5.3.8_2
 
 February 2020 to September 2025
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_DEFINE([__SSLMITM],[""],[Define to enable SSL MITM])
 AC_DEFINE([FD_SETSIZE_OVERIDE],[""],[Define to allow DANS_MAXFD to exceed FD_SETSIZE])
 
 AC_PREREQ(2.57)
-AC_INIT(e2guardian, 5.3.8)
+AC_INIT(e2guardian, 5.3.8_2)
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_HEADERS([dgconfig.h])
 AC_CONFIG_MACRO_DIR([m4])

--- a/notes/NEWIN_v5
+++ b/notes/NEWIN_v5
@@ -1,4 +1,4 @@
-This is the v5.3.8 stable version
+This is the v5.3.8_2 stable version
 
 Note that large sections of the code has been re-written and there are
 significant changes to the configuration files in v5.


### PR DESCRIPTION
## Summary
- update the package version in `configure.ac` to 5.3.8_2
- refresh top-level documentation references to the new 5.3.8_2 release number

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e4cb0e50832eaa7e22c1b9a05291