### PR TITLE
Fix authexception helper forward declarations

### DIFF
--- a/src/ListContainer.cpp
+++ b/src/ListContainer.cpp
@@ -23,12 +23,79 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <list>
+#include <string>
+#include <cerrno>
+#include <cstring>
+
+extern bool is_daemonised;
+extern thread_local std::string thread_id;
+
+namespace {
+
+bool ensureAuthexceptionListExists(const char *filename)
+{
+    static const char *kSuffixes[] = {
+        "authexceptioniplist",
+        "authexceptionsitelist",
+        "authexceptionurllist"
+    };
+
+    std::string path(filename);
+    for (const char *suffix : kSuffixes) {
+        size_t suffix_len = strlen(suffix);
+        if (path.length() >= suffix_len &&
+            path.compare(path.length() - suffix_len, suffix_len, suffix) == 0) {
+            struct stat status;
+            if (stat(filename, &status) == 0) {
+                return true;
+            }
+
+            if (errno != ENOENT) {
+                if (!is_daemonised) {
+                    std::cerr << thread_id << "Unable to access list " << filename
+                              << ": " << strerror(errno) << std::endl;
+                }
+                syslog(LOG_ERR, "Unable to access list %s: %s", filename, strerror(errno));
+                return false;
+            }
+
+            std::ofstream newlist(filename, std::ios::out | std::ios::trunc);
+            if (!newlist.good()) {
+                if (!is_daemonised) {
+                    std::cerr << thread_id << "Unable to create missing list " << filename
+                              << ": " << strerror(errno) << std::endl;
+                }
+                syslog(LOG_ERR, "Unable to create missing list %s: %s", filename, strerror(errno));
+                return false;
+            }
+
+            if (strcmp(suffix, "authexceptioniplist") == 0) {
+                newlist << "#Client IPs allowed prior to authentication" << std::endl;
+            } else {
+                newlist << "#Access allowed prior to authentication" << std::endl;
+            }
+            newlist.close();
+
+            if (chmod(filename, S_IRUSR | S_IWUSR | S_IRGRP) != 0) {
+                syslog(LOG_WARNING, "Unable to set permissions on %s: %s", filename, strerror(errno));
+            }
+
+            if (!is_daemonised) {
+                std::cerr << thread_id << "Created missing authexception list " << filename << std::endl;
+            }
+            syslog(LOG_INFO, "Created missing authexception list %s", filename);
+            return true;
+        }
+    }
+
+    return true;
+}
+
+} // namespace
 
 // GLOBALS
 
-extern bool is_daemonised;
 extern OptionContainer o;
-extern thread_local std::string thread_id;
 
 // DEFINES
 
@@ -519,6 +586,9 @@ bool ListContainer::readItemList(const char *filename, bool startswith, int filt
     std::cerr << thread_id << filename << std::endl;
 #endif
     //struct stat s;
+    if (!ensureAuthexceptionListExists(filename)) {
+        return false;
+    }
     filedate = getFileDate(filename);
     size_t len = 0;
     try {


### PR DESCRIPTION
## Summary
- declare is_daemonised and thread_id before the authexception helper so the compiler sees the externs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e324a8a0a8832e9ddbe3c4813756c9