### PR TITLE
Handle truncated TLS extension lists when parsing SNI

### DIFF
--- a/doc/tls_sni_stack_overflow_analysis.md
+++ b/doc/tls_sni_stack_overflow_analysis.md
@@ -1,0 +1,24 @@
+# TLS SNI stack overflow analysis
+
+## Contexto
+O `e2guardian` sofreu "core crash" e mensagens de `stack overflow detected` quando operava em modo de proxy transparente com interceptação SSL. O problema não se reproduzia com proxy declarado, indicando que estava ligado ao código que analisa o ClientHello TLS para obter o SNI.
+
+## Comportamento antigo
+A função `get_TLS_SNI` percorria o *ClientHello* manipulando ponteiros brutos. Ao localizar a extensão de Server Name Indication, ela escrevia um byte `\0` logo após o nome extraído para reutilizar o mesmo *buffer* como uma `char*` terminada em NUL:
+
+```c++
+*(curr + namelen) = (char)0;
+return (char*)curr;
+```
+
+Entretanto, `curr` apontava para dentro do *ClientHello* recebido por `recv(MSG_PEEK)`. Esse *buffer* tinha o tamanho exato da mensagem enviada pelo cliente. Caso o nome SNI fosse posicionado perto do fim do pacote, `curr + namelen` apontava exatamente para o byte imediatamente após o *ClientHello*. Escrever o `\0` nessa posição resultava em escrita fora dos limites e corrompia a pilha (o *buffer* local que armazena os bytes do handshake). Isso explica os `stack overflow detected` do `libc` e os *core dumps* vistos no ambiente FreeBSD.
+
+Além disso, vários cálculos de comprimento assumiam implicitamente que haveria bytes suficientes antes de cada acesso. Se o pacote fosse truncado ou se o cliente enviasse campos menores que o esperado, `*(unsigned short*)curr` e leituras subsequentes poderiam avançar `curr` além do final do *buffer* sem uma checagem de limites clara, favorecendo o mesmo tipo de corrupção.
+
+## Correção aplicada
+As alterações introduzidas:
+
+1. **Validação estrita de limites** – cada passo da navegação dentro do *ClientHello* verifica se há bytes suficientes antes de ler ou avançar ponteiros. Caso contrário, a função retorna `NULL` sem tocar o *buffer*. Quando o pacote capturado é menor do que o tamanho total das extensões informado no ClientHello, o laço limita a busca ao que foi efetivamente recebido, evitando falsos negativos ao mesmo tempo em que impede leitura fora dos limites.
+2. **Cópia para `thread_local std::string`** – em vez de escrever `\0` dentro do *buffer* espiado, o nome SNI é copiado para uma `std::string` específica da *thread*. O ponteiro retornado aponta para o conteúdo seguro dessa string, evitando qualquer escrita fora dos limites do *ClientHello* original.
+
+Essa combinação elimina a gravação fora da pilha e garante que entradas malformadas não causem estouro de pilha, estabilizando o modo transparente com interceptação SSL.

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -42,6 +42,7 @@
 #include <istream>
 #include <sstream>
 #include <memory>
+#include <string>
 
 #ifdef ENABLE_ORIG_IP
 #include <linux/types.h>
@@ -3585,49 +3586,81 @@ std::cerr << thread_id << " -got peer connection - clientip is " << clientip << 
 }
 
 
-char *get_TLS_SNI(char *inbytes, int* len)
+char *get_TLS_SNI(char *inbytes, int *len)
 {
-    unsigned char *bytes = reinterpret_cast<unsigned char*>(inbytes);
-    unsigned char *curr;
-    unsigned char *ebytes;
-     ebytes = bytes + *len;
-    if (*len < 44) return NULL;
+    unsigned char *bytes = reinterpret_cast<unsigned char *>(inbytes);
+    unsigned char *ebytes = bytes + *len;
+
+    if (*len < 44)
+        return NULL;
+
     unsigned char sidlen = bytes[43];
-    curr = bytes + 1 + 43 + sidlen;
-    if (curr > ebytes) return NULL;
-    unsigned short cslen = ntohs(*(unsigned short*)curr);
-    curr += 2 + cslen;
-    if (curr > ebytes) return NULL;
-    unsigned char cmplen = *curr;
-    curr += 1 + cmplen;
-    if (curr > ebytes) return NULL;
-    unsigned char *maxchar = curr + 2 + ntohs(*(unsigned short*)curr);
+    unsigned char *curr = bytes + 44 + sidlen;
+    if (curr > ebytes)
+        return NULL;
+
+    if (ebytes - curr < 2)
+        return NULL;
+    unsigned short cslen = ntohs(*(unsigned short *)curr);
     curr += 2;
+
+    if (ebytes - curr < cslen)
+        return NULL;
+    curr += cslen;
+
+    if (ebytes - curr < 1)
+        return NULL;
+    unsigned char cmplen = *curr;
+    curr += 1;
+
+    if (ebytes - curr < cmplen)
+        return NULL;
+    curr += cmplen;
+
+    if (ebytes - curr < 2)
+        return NULL;
+    unsigned short total_ext_len = ntohs(*(unsigned short *)curr);
+    unsigned char *maxchar = curr + 2 + total_ext_len;
+    curr += 2;
+
+    if (maxchar > ebytes)
+        maxchar = ebytes;
+
     unsigned short ext_type = 1;
     unsigned short ext_len;
-    while(curr < maxchar && ext_type != 0)
+    while (curr < maxchar && ext_type != 0)
     {
-        if (curr > ebytes) return NULL;
-        ext_type = ntohs(*(unsigned short*)curr);
+        if (ebytes - curr < 4)
+            return NULL;
+        ext_type = ntohs(*(unsigned short *)curr);
         curr += 2;
-        if (curr > ebytes) return NULL;
-        ext_len = ntohs(*(unsigned short*)curr);
+        ext_len = ntohs(*(unsigned short *)curr);
         curr += 2;
-        if(ext_type == 0)
+
+        if (ext_type == 0)
         {
-            curr += 3;
-            if (curr > ebytes) return NULL;
-            unsigned short namelen = ntohs(*(unsigned short*)curr);
+            if (ebytes - curr < 3)
+                return NULL;
+            curr += 1; // name type
+            unsigned short namelen = ntohs(*(unsigned short *)curr);
             curr += 2;
-            if ((curr + namelen) > ebytes) return NULL;
-            //*len = namelen;
-            *(curr +namelen) = (char)0;
-            return (char*)curr;
+
+            if (ebytes - curr < namelen)
+                return NULL;
+
+            static thread_local std::string sni_host;
+            sni_host.assign(reinterpret_cast<const char *>(curr), namelen);
+            // Preserve the historical behaviour where the caller's length is the
+            // size of the ClientHello peek.  Only hand back the hostname.
+            return const_cast<char *>(sni_host.c_str());
         }
-        else curr += ext_len;
+
+        if (ebytes - curr < ext_len)
+            return NULL;
+        curr += ext_len;
     }
-    //if (curr != maxchar) throw std::exception("incomplete SSL Client Hello");
-    return NULL; //SNI was not present
+
+    return NULL; // SNI was not present
 }
 
 #endif


### PR DESCRIPTION
## Summary
- cap the SNI extension search to the bytes actually peeked so partial ClientHello messages still yield hostnames
- leave the caller's recorded peek length untouched while keeping the hostname copy in a thread-local buffer
- document that the parser now limits iteration to the received extension bytes to avoid false negatives on truncated hellos

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6fcf2d520832e859e27ffd89c2efa