### PR TITLE
Fix HTTP header port tracking in transparent mode

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -572,6 +572,7 @@ void HTTPHeader::setURL(String &url)
         std::cerr << thread_id << " to " << (*pport) << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
 #endif
     }
+    this->port = static_cast<unsigned int>(port);
     // Don't just cache the URL we're sent - getUrl() performs some other
     // processing, notably stripping the port part. Caching here will
     // bypass all that.

--- a/src/IPList.hpp
+++ b/src/IPList.hpp
@@ -7,7 +7,9 @@
 
 // INCLUDES
 
+#include <cstdint>
 #include <list>
+#include <vector>
 
 // DECLARATIONS
 


### PR DESCRIPTION
## Summary
- update HTTPHeader::setURL to keep the parsed destination port in sync with the header object
- add the missing cstdint/vector includes in IPList.hpp so the tree continues to compile

## Testing
- make -s

------
https://chatgpt.com/codex/tasks/task_e_68ed5962bd24832e91769fc15c260c86