### PR TITLE
feat: reutilizar IP original no proxy transparente

### DIFF
--- a/analysis/ChangeLog_v5.5_useoriginalip.txt
+++ b/analysis/ChangeLog_v5.5_useoriginalip.txt
@@ -1,0 +1,1 @@
+New useoriginalip option - solves issues with some apps who use non-stqndard SNI.

--- a/analysis/ConnectionHandler_v5.5_useoriginalip.cpp
+++ b/analysis/ConnectionHandler_v5.5_useoriginalip.cpp
@@ -1,0 +1,39 @@
+// Extract from e2guardian v5.5.8r ConnectionHandler::connectUpstream
+if (cm.isdirect) {
+    String des_ip;
+    if (cm.isiphost)
+        des_ip = cm.urldomain;
+    if (o.conn.use_original_ip_port && cm.got_orig_ip && (cm.connect_site == cm.urldomain))
+        des_ip = cm.orig_ip;
+    if (des_ip.length() > 0) {
+        // ...
+        int rc = sock.connect(des_ip, port);
+        if (rc < 0) {
+            lerr_mess = 203;
+            continue;
+        }
+        return rc;
+    }
+}
+
+// Extract from e2guardian v5.5.8r ConnectionHandler::get_original_ip_port
+if (getsockopt(peerconn.getFD(), SOL_IP, SO_ORIGINAL_DST, &origaddr, &origaddrlen) < 0) {
+    E2LOGGER_error("Failed to get client's original destination IP: ", strerror(errno));
+    return false;
+} else {
+    checkme.orig_ip = inet_ntop(AF_INET, &origaddr.sin_addr, res, sizeof(res));
+    if (o.net.check_ip.size() > 0) {
+        for (auto it = o.net.check_ip.begin(); it != o.net.check_ip.end(); it++) {
+            if (*it == checkme.orig_ip) {
+                checkme.orig_ip.clear();
+                return false;
+            }
+        }
+    }
+    checkme.orig_port = ntohs(origaddr.sin_port);
+    checkme.got_orig_ip = true;
+    return true;
+}
+
+// Extract from e2guardian v5.5.8r OptionContainer::findConnectionHandlerOptions
+conn.use_original_ip_port = cr.findoptionB("useoriginalip");

--- a/analysis/FatController_v5.5_snippets.cpp
+++ b/analysis/FatController_v5.5_snippets.cpp
@@ -77,3 +77,26 @@ void log_listener(Queue<std::string> *log_Q, bool is_RQlog) {
         // ... processamento de log ...
     }
 }
+
+// Configuração de campos em branco no formato de log (v5.5.8r)
+std::string blank_str;
+if (o.log.use_dash_for_blanks)
+    blank_str = "-";
+else
+    blank_str = "";
+
+if (o.log.use_dash_for_blanks && logline == "") {
+    s = "-";
+} else if (!o.log.use_dash_for_blanks && logline == "-") {
+    s = "";
+} else {
+    s = logline;
+}
+
+// Escrita do pid para systemd antes do daemonizar (v5.5.8r)
+int rc = sysv_writepidfile(pidfilefd, 0); // também fecha o fd
+if (rc != 0) {
+    E2LOGGER_error("Error writing to the e2guardian.pid file: ", strerror(errno));
+    delete[] serversockfds;
+    return false;
+}

--- a/analysis/comparativo_v5.5_v5.3.8.md
+++ b/analysis/comparativo_v5.5_v5.3.8.md
@@ -1,0 +1,40 @@
+# Comparativo entre v5.5.8r e v5.3.8 (branch `work`)
+
+## Melhorias já incorporadas na base 5.3.8
+- **Flags atômicas para rotação dos logs** – a 5.3.8 já expõe `rotate_access`, `rotate_request` e `rotate_dstat`, consumindo-as nos listeners para reabrir arquivos apenas quando necessário. 【F:src/FatController.cpp†L126-L205】【F:src/FatController.cpp†L810-L838】
+- **Ordem correta da máscara de sinais** – o master aplica `pthread_sigmask` antes de iniciar `log_listener` e `RQlog_listener`, impedindo que as threads filhas recebam sinais indevidos, assim como observado na série 5.5.【F:src/FatController.cpp†L1668-L1689】【F:analysis/FatController_v5.5_snippets.cpp†L34-L63】
+- **Rotação dos dstat sem reinício** – `stat_rec::reset` fecha e reabre o `FILE*` quando `rotate_dstat` é sinalizado, o que elimina a necessidade de recriar threads durante `SIGUSR1`. 【F:src/FatController.cpp†L176-L230】【F:analysis/FatController_v5.5_snippets.cpp†L15-L32】
+
+## Diferenças remanescentes
+| Tema | v5.3.8 (`work`) | v5.5.8r | Impacto/Complexidade |
+|------|-----------------|---------|----------------------|
+| **Backend de logging** | Uso direto de `std::ofstream`/`syslog`, com fechamento manual de arquivos e sem camadas para UDP/STDOUT. 【F:src/FatController.cpp†L810-L838】 | Centralização via `Logger`, com macros `E2LOGGER_*`, flush dedicado e suporte a múltiplos destinos. 【F:analysis/FatController_v5.5_snippets.cpp†L15-L77】 | Alta – requer portar `Logger.*` e ajustar dezenas de chamadas; bom para roadmap, não para mudança rápida. |
+| **Placeholders em branco no accesslog** | Sempre converte strings vazias em `"-"`, independentemente da preferência do operador. 【F:src/FatController.cpp†L840-L918】 | Configura `use_dash_for_blanks` e permite preservar campos vazios reais. 【F:analysis/FatController_v5.5_snippets.cpp†L81-L94】 | Baixa – basta acrescentar um `bool` no `OptionContainer`, ler a nova opção e ajustar o branch que formata `logline`. |
+| **Proxy transparente e IP original** | Conexões diretas dependem exclusivamente de `cm.urldomain` ou de um `getsockopt` protegido por `ENABLE_ORIG_IP`, que apenas valida o host header e não reutiliza o IP original ao reconectar. 【F:src/ConnectionHandler.cpp†L460-L557】【F:src/ConnectionHandler.cpp†L953-L1018】 | Introduz a flag `useoriginalip` e, quando ativa, reutiliza `checkme.orig_ip`/`orig_port` obtidos via `SO_ORIGINAL_DST`, inclusive desconsiderando IPs pertencentes ao próprio proxy para evitar loops. 【F:analysis/ConnectionHandler_v5.5_useoriginalip.cpp†L1-L39】 | Média – exige portar a flag, extrair uma rotina `get_original_ip_port()` e ajustá-la para compilar fora do `#ifdef ENABLE_ORIG_IP`. |
+| **PID file antes da daemonização** | Escreve o PID apenas após o `daemonise`, o que dificulta supervisores que esperam o PID do master imediatamente. 【F:src/FatController.cpp†L1669-L1675】【F:src/SysV.cpp†L183-L197】 | Chama `sysv_writepidfile(pidfilefd, 0)` antes de soltar o terminal e trata erro via `Logger`. 【F:analysis/FatController_v5.5_snippets.cpp†L96-L102】 | Baixa – adaptar `sysv_writepidfile` para aceitar um PID opcional (default `getpid()`) e realizar a chamada extra. |
+| **Eco no console durante `--no-daemon`** | Logs iniciais dependem exclusivamente do syslog; quem roda em foreground não vê mensagens até o daemon anexar ao syslog. 【F:src/FatController.cpp†L1670-L1678】 | `Logger` escreve simultaneamente em `stderr` enquanto `g_is_starting` for verdadeiro. 【F:analysis/FatController_v5.5_snippets.cpp†L96-L102】 | Média – precisa de um guardião semelhante (`g_is_starting`) e chamadas extras a `std::cerr` ou uma versão simplificada do `Logger`. |
+
+## Recomendações imediatas (baixo esforço)
+1. **Adicionar suporte a `usedashforblank`**
+   - Declarar `bool use_dash_for_blanks = true;` no `OptionContainer`, ler a opção no parser e ajustar o bloco do `log_listener` que normaliza cada `logline` para respeitar a configuração.【F:src/FatController.cpp†L840-L918】【F:analysis/FatController_v5.5_snippets.cpp†L81-L94】
+   - Benefício: compatibilidade com setups que exigem colunas vazias em formato CSV, além de paridade funcional com 5.5.
+
+2. **Atualizar `sysv_writepidfile` para aceitar PID explícito**
+   - Alterar a assinatura para `int sysv_writepidfile(int pidfilefd, pid_t pid = 0)` e usar `pid == 0 ? getpid() : pid` internamente, mantendo compatibilidade com chamadas existentes.【F:src/SysV.cpp†L183-L197】
+   - Invocar a função antes e depois da daemonização, replicando o padrão da 5.5 para que scripts `systemd` ou `rc` consigam identificar o processo master de imediato.【F:analysis/FatController_v5.5_snippets.cpp†L96-L102】
+
+## Itens para roadmap (maior esforço)
+- **Portar o `Logger` completo** para liberar destinos múltiplos (UDP/STDOUT), formatação flexível e mecanismos de flush centralizados. Isso envolve introduzir `Logger.cpp/.hpp`, substituir `syslog` por macros `E2LOGGER_*` e ajustar a estrutura de opções (`o.log.*`).【F:analysis/FatController_v5.5_snippets.cpp†L15-L77】
+- **Rever o pipeline de stats** para eliminar o uso direto de `FILE*`, passando a reutilizar o `Logger` também para `dstats`, o que uniformiza a rotação e simplifica o código.【F:analysis/FatController_v5.5_snippets.cpp†L15-L32】
+
+## Correção de 127.0.0.1 no proxy transparente
+
+Os relatos de múltiplos bloqueios aparentes para `127.0.0.1` decorrem de implantações transparentes onde o e2guardian reconecta-se ao próprio IP local ao invés do destino original. A série 5.5 introduziu a opção `useoriginalip` justamente para direcionar HTTP/HTTPS transparentes ao IP/porta capturados via `SO_ORIGINAL_DST`, solução destacada tanto no `ChangeLog` quanto no comentário do `e2guardian.conf`.【F:analysis/ChangeLog_v5.5_useoriginalip.txt†L1-L1】【F:analysis/e2guardian.conf_v5.5_useoriginalip.txt†L1-L9】 O trecho portado acima mostra que, quando a flag está ligada, o `connectUpstream` reutiliza `cm.orig_ip` e ignora IPs pertencentes ao próprio appliance, evitando que logs apontem para `127.0.0.1`.【F:analysis/ConnectionHandler_v5.5_useoriginalip.cpp†L1-L35】
+
+Na base 5.3.8 o caminho direto continua preso ao `cm.urldomain` e o bloco protegido por `ENABLE_ORIG_IP` apenas valida o host header, sem alterar o destino do `connect()` subsequente, o que explica a recorrência dos registros em `127.0.0.1` quando não há `Host:`/SNI válidos.【F:src/ConnectionHandler.cpp†L460-L557】【F:src/ConnectionHandler.cpp†L953-L1018】 Portar a melhoria requer três passos de baixo impacto:
+
+1. **Adicionar a flag de configuração.** Estender o parser para aceitar `useoriginalip` lado a lado de `logconnectionhandlingerrors`, armazenando em um novo `bool` (`use_original_ip_port`).【F:src/OptionContainer.cpp†L699-L736】
+2. **Extrair `get_original_ip_port()`.** Reaproveitar o bloco atual que chama `getsockopt(SO_ORIGINAL_DST)` para popular `checkme.orig_ip`/`orig_port`, removendo o `#ifdef ENABLE_ORIG_IP` e encapsulando numa função reutilizável, seguindo o padrão da 5.5.【F:src/ConnectionHandler.cpp†L953-L1018】【F:analysis/ConnectionHandler_v5.5_useoriginalip.cpp†L19-L35】
+3. **Usar o IP original no `connectUpstream`.** Reutilizar `cm.orig_ip` quando a flag estiver ativa e quando o proxy estiver em modo direto, espelhando a condição da 5.5, para que as tentativas sejam encaminhadas ao destino interceptado em vez de `127.0.0.1`.【F:src/ConnectionHandler.cpp†L460-L516】【F:analysis/ConnectionHandler_v5.5_useoriginalip.cpp†L1-L17】
+
+Com essas adaptações o branch 5.3.8 passa a reproduzir o comportamento da série 5.5 sem renomear arquivos nem alterar a árvore de diretórios, resolvendo o ruído de bloqueios direcionados ao loopback e melhorando compatibilidade com aplicativos que omitem o host/SNI.

--- a/analysis/e2guardian.conf_v5.5_useoriginalip.txt
+++ b/analysis/e2guardian.conf_v5.5_useoriginalip.txt
@@ -1,0 +1,9 @@
+# Extract from e2guardian v5.5.8r sample config
+#useoriginalip = on
+# This option only applies when request is transparent (http or https),
+# when no upstream proxy is used, and where it is possible to detect
+# the original destination ip & port
+# When enabled the upstream request will be directed at the original ip and port
+# and no DNS lookup will be performed.
+# This solves the 'snapchat' issue and also should increase speed of connection.
+# Currently this ONLY works on linux systems.

--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -568,7 +568,13 @@ usexforwardedfor = off
 # it on or off
 logconnectionhandlingerrors = on
 
-#sets the number of worker threads to use 
+# When enabled, transparent connections intercepted via iptables/pf will reuse
+# the original destination IP/port retrieved from the kernel.  This prevents
+# reconnect attempts from looping back to the proxy IP (e.g. 127.0.0.1) and
+# keeps access logs aligned with the real upstream address. on | off
+useoriginalip = off
+
+#sets the number of worker threads to use
 #
 # This figure is the maximum number of concurrent connections.
 # If more connections are made, connections will queue until a worker thread is free.

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -456,21 +456,81 @@ ConnectionHandler::sendFile(Socket *peerconn, NaughtyFilter &cm, String &url, bo
     return sent;
 }
 
+bool
+ConnectionHandler::get_original_ip_port(NaughtyFilter &checkme, Socket &peerconn, bool log_error)
+{
+    sockaddr_in origaddr;
+    socklen_t origaddrlen(sizeof(sockaddr_in));
+
+#ifdef SOL_IP
+#ifndef SO_ORIGINAL_DST
+#define SO_ORIGINAL_DST 80
+#endif
+    if (getsockopt(peerconn.getFD(), SOL_IP, SO_ORIGINAL_DST, &origaddr, &origaddrlen) < 0)
+#else
+    if (getsockname(peerconn.getFD(), (struct sockaddr *)&origaddr, &origaddrlen) < 0)
+#endif
+    {
+        int saved_errno = errno;
+        checkme.orig_ip = "";
+        checkme.orig_port = 0;
+        checkme.got_orig_ip = false;
+        if (log_error)
+            syslog(LOG_ERR, "%sFailed to get client's original destination IP: %s", thread_id.c_str(), strerror(saved_errno));
+        return false;
+    }
+
+    char res[INET_ADDRSTRLEN];
+    checkme.orig_ip = inet_ntop(AF_INET, &origaddr.sin_addr, res, sizeof(res));
+    if (checkme.orig_ip == peerconn.getLocalIP()) {
+        checkme.orig_ip = "";
+        checkme.orig_port = 0;
+        checkme.got_orig_ip = false;
+        return false;
+    }
+
+    if (!checkme.orig_ip.empty()) {
+        for (auto &ip : o.filter_ip) {
+            if (checkme.orig_ip == ip) {
+                checkme.orig_ip.clear();
+                checkme.orig_port = 0;
+                checkme.got_orig_ip = false;
+                return false;
+            }
+        }
+        for (auto &ip : o.check_ip) {
+            if (checkme.orig_ip == ip) {
+                checkme.orig_ip.clear();
+                checkme.orig_port = 0;
+                checkme.got_orig_ip = false;
+                return false;
+            }
+        }
+    }
+
+    checkme.orig_port = ntohs(origaddr.sin_port);
+    checkme.got_orig_ip = true;
+    return true;
+}
+
 int
 ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0)   // connects to to proxy or directly
 {
     if (port == 0)
         port = cm.request_header->port;
-    String sport(port);
+
+    auto port_is_filter_port = [this](int candidate) {
+        String sport(candidate);
+        for (auto it = o.filter_ports.begin(); it != o.filter_ports.end(); it++) {
+            if (*it == sport)
+                return true;
+        }
+        return false;
+    };
+
     int lerr_mess = 0;
     int retry = -1;
-    bool may_be_loop = false;
-    for (auto it = o.filter_ports.begin(); it != o.filter_ports.end(); it++) {
-        if (*it == sport) {
-            may_be_loop = true;
-            break;
-        }
-    }
+    bool may_be_loop = port_is_filter_port(port);
 #ifdef DGDEBUG
     std::cerr << thread_id << "May_be_loop = " << may_be_loop << " "  << " port " << port << std::endl;
 #endif
@@ -486,8 +546,20 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
         cm.upfailure = false;
         if (cm.isdirect) {
             String des_ip;
-            if (cm.isiphost) {
+            bool use_direct_ip = false;
+            if (o.use_original_ip_port && cm.got_orig_ip && (cm.connect_site == cm.urldomain) && !cm.orig_ip.empty()) {
+                des_ip = cm.orig_ip;
+                use_direct_ip = true;
+                if (cm.orig_port > 0 && cm.orig_port != port) {
+                    port = cm.orig_port;
+                    may_be_loop = port_is_filter_port(port);
+                }
+            } else if (cm.isiphost) {
                 des_ip = cm.urldomain;
+                use_direct_ip = true;
+            }
+
+            if (use_direct_ip) {
                 if (may_be_loop) {  // check check_ip list
                     bool do_break = false;
                     if (o.check_ip.size() > 0) {
@@ -827,6 +899,9 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
 //
             // do this normalisation etc just the once at the start.
             checkme.setURL(ismitm);
+
+            if (o.use_original_ip_port && !header.isProxyRequest)
+                get_original_ip_port(checkme, peerconn);
 
             if(o.log_requests) {
                 std::string fnt;
@@ -3343,27 +3418,8 @@ std::cerr << thread_id << " -got peer connection - clientip is " << clientip << 
 
             ++dystat->reqs;
         }
-        }
-        {   // get original IP destination & port
-
-                sockaddr_in origaddr;
-                socklen_t origaddrlen(sizeof(sockaddr_in));
-                if (
-#ifdef SOL_IP       // linux
-#define SO_ORIGINAL_DST 80
-                        getsockopt(peerconn.getFD(), SOL_IP, SO_ORIGINAL_DST, &origaddr, &origaddrlen ) < 0
-#else                       // BSD
-                        getsockname(peerconn.getFD(), (struct sockaddr *)&origaddr, &origaddrlen) < 0
-#endif
-                ) {
-                    syslog(LOG_ERR, "%sFailed to get client's original destination IP: %s", thread_id.c_str(), strerror(errno));
-                    return -1;
-                } else {
-                     char res[INET_ADDRSTRLEN];
-                    checkme.orig_ip = inet_ntop(AF_INET,&origaddr.sin_addr,res,sizeof(res));
-                    checkme.orig_port = ntohs(origaddr.sin_port);
-                }
-         }
+        if (!get_original_ip_port(checkme, peerconn, true))
+            return -1;
 
         if(!checkme.hasSNI) {
         checkme.url = checkme.orig_ip;

--- a/src/ConnectionHandler.hpp
+++ b/src/ConnectionHandler.hpp
@@ -96,6 +96,8 @@ class ConnectionHandler
 
     String dns_error(int herror);
 
+    bool get_original_ip_port(NaughtyFilter &checkme, Socket &peerconn, bool log_error = false);
+
     // write a log entry containing the given data (if required)
   //  void doLog(std::string &who, std::string &from, String &where, unsigned int &port,
   //      std::string &what, String &how, off_t &size, std::string *cat, bool isnaughty, int naughtytype,

--- a/src/NaughtyFilter.cpp
+++ b/src/NaughtyFilter.cpp
@@ -130,6 +130,11 @@ void NaughtyFilter::reset()
     isGrey = false;
     isSSLGrey = false;
     isSearch = false;
+    hasSNI = false;
+    isTLS = false;
+    orig_ip = "";
+    orig_port = 0;
+    got_orig_ip = false;
     message_no = 0;
     is_text = false;
     filtergroup = 0;

--- a/src/NaughtyFilter.hpp
+++ b/src/NaughtyFilter.hpp
@@ -37,6 +37,7 @@ class NaughtyFilter
     bool isTLS = false;     // used in transparent https mode
     String orig_ip;     // used in transparent https mode
     int orig_port = 0;     // used in transparent https mode
+    bool got_orig_ip = false; // used when recovering original destination
 
     // return true or false?
     bool isReturn = false;

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -701,6 +701,11 @@ bool OptionContainer::read(std::string& filename, int type)
         } else {
             logconerror = false;
         }
+        if (findoptionS("useoriginalip") == "on") {
+            use_original_ip_port = true;
+        } else {
+            use_original_ip_port = false;
+        }
         if (findoptionS("logchildprocesshandling") == "on") {
             logchildprocs = true;
         } else {

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -65,6 +65,7 @@ class OptionContainer
     bool use_xforwardedfor = false;
     std::deque<String> xforwardedfor_filter_ip;
     bool logconerror = false;
+    bool use_original_ip_port = false;
     bool logchildprocs = false;
     bool log_ssl_errors = false;
     int url_cache_number = 0;


### PR DESCRIPTION
## Resumo
- adiciona a opção `useoriginalip` nas configurações principais e expõe o respectivo indicador em `OptionContainer`
- captura e valida o destino original das conexões transparentes para reaproveitar IP/porta no `connectUpstream`
- inicializa e reutiliza os novos metadados do `NaughtyFilter`, aplicando a recuperação de IP original também no fluxo THTTPS

## Testes
- não executado (mudanças de código aguardando testes manuais)

------
https://chatgpt.com/codex/tasks/task_e_68eda1b1f4ec832eaa259fd95086ed76