### PR TITLE
Fix missing brace in THTTPS handler

### DIFF
--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -3620,9 +3620,9 @@ std::cerr << thread_id << " -got peer connection - clientip is " << clientip << 
                 doLog(clientuser, clientip, checkme);
             }
 
-
-                proxysock.close(); // close connection to proxy
+            proxysock.close(); // close connection to proxy
         }
+    }
     }
     catch (const std::exception &e)
     {


### PR DESCRIPTION
## Summary
- add the missing closing brace for the try block in `handleTHTTPSConnection` so that the catch handler is parsed correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68edb96acfe4832e9324fcedc891993e