### PR TITLE
Avoid blocking workers while sending block pages

### DIFF
--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -2176,7 +2176,10 @@ bool ConnectionHandler::denyAccess(Socket *peerconn, Socket *proxysock, HTTPHead
 
     // we blocked the request, so flush the client connection & close the proxy connection.
     if ((*checkme).isItNaughty) {
-        (*peerconn).breadyForOutput(o.proxy_timeout); //as best a flush as I can
+        // Avoid keeping the worker thread blocked on slow or stalled clients.
+        // `writeString()` already performs a blocking flush, so a non-blocking
+        // readiness check is sufficient before we drop the connection.
+        (*peerconn).readyForOutput();
         (*proxysock).close(); // close connection to proxy
         // we said no to the request, so return true, indicating exit the connhandler
         return true;


### PR DESCRIPTION
## Summary
- avoid blocking HTTP workers on long proxy timeouts after serving a block page by replacing the blocking flush with a non-blocking readiness check

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eec8f084e0832e87e7b5b873e2cd57