### PR TITLE
Add missing domainsnobypass list to default installation

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -1,4 +1,5 @@
-DISTCLEANFILES = Makefile.in 
+DISTCLEANFILES = Makefile.in \
+                 domainsnobypass
 
 E2DATADIR = $(E2CONFDIR)/lists
 
@@ -11,9 +12,10 @@ if NEED_DMLISTS
 SUBDIRS += downloadmanagers
 endif
 
-WLISTS = README
- 
-EXTRA_DIST = 
+WLISTS = README \
+        domainsnobypass
+
+EXTRA_DIST = domainsnobypass.in
 
 install-data-local: 
 	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \

--- a/configs/lists/domainsnobypass.in
+++ b/configs/lists/domainsnobypass.in
@@ -1,0 +1,63 @@
+# Users are not allowed to bypass domains in this list
+
+# Don't bother with the www. or the http://
+
+# NOTE: Sites using just IP should be put into bannedsiteiplistwithbypass
+
+# You can include
+#.tld so for example you can match .gov for example
+
+#.Include<@E2CONFDIR@/anotherbannedurllist>
+
+# You can have multiple .Includes.
+
+# WARNING: Old style Blanket blocks in this file will be silently ignored
+
+# .Include<@E2CONFDIR@/lists/blacklists/ads/domains>
+
+# Remove the # from the following and edit as needed to use a stock
+# squidGuard/urlblacklists collection.
+#.Include<@E2CONFDIR@/lists/blacklists/adult/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/aggressive/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/artnudes/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/audio-video/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/beerliquorinfo/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/beerliquorsale/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/chat/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/childcare/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/clothing/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/culinary/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/dialers/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/drugs/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/entertainment/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/forums/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/frencheducation/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/gambling/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/government/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/hacking/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/homerepair/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/hygiene/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/isp/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/jobsearch/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/malware/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/marketingware/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/military/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/mobilesms/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/news/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/porn/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/redirector/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/remotecontrol/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/religion/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/safesearch/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/sciencefiction/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/sexeducation/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/shopping/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/sports/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/tracking/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/violence/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/warez/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/webmail/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/weapons/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/webphone/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/redirector/domains>
+#.Include<@E2CONFDIR@/lists/blacklists/proxy/domains>

--- a/configure.ac
+++ b/configure.ac
@@ -672,8 +672,9 @@ configs/e2guardian.conf
 configs/e2guardianf1.conf
 configs/examplef1.story
 configs/Makefile
-configs/lists/Makefile
-configs/lists/common/Makefile
+ configs/lists/Makefile
+ configs/lists/domainsnobypass
+ configs/lists/common/Makefile
 configs/lists/example.group/Makefile
 configs/lists/phraselists/Makefile
 configs/lists/oldphraselists/Makefile


### PR DESCRIPTION
## Summary
- add a packaged domainsnobypass template to the default lists
- install the template with the default configuration data and ensure it is generated by configure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f12e64a240832ea8ad00756297f04c