### PR TITLE
Add missing ipnobypass list to installation

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -13,9 +13,11 @@ SUBDIRS += downloadmanagers
 endif
 
 WLISTS = README \
-        domainsnobypass
+        domainsnobypass \
+        ipnobypass
 
-EXTRA_DIST = domainsnobypass.in
+EXTRA_DIST = domainsnobypass.in \
+             ipnobypass
 
 install-data-local: 
 	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \

--- a/configs/lists/ipnobypass
+++ b/configs/lists/ipnobypass
@@ -1,0 +1,12 @@
+# Users are not allowed to bypass IP addresses in this list
+#
+# Use this list to prevent bypassing filters for specific hosts
+# identified by IP address.
+#
+# Single IPs, ranges, and CIDR subnets can be used, for example:
+# 192.0.2.10
+# 198.51.100.50-198.51.100.60
+# 203.0.113.0/24
+#
+# Lines starting with a # are treated as comments.
+# Leave the list empty to disable IP bypass restrictions.


### PR DESCRIPTION
## Summary
- install the ipnobypass list alongside other default list files
- provide a template ipnobypass file describing how to populate the list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f136777f28832e99c810e56eabe3d8