### PR TITLE
Ensure contentscanner exception lists reach base install

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -25,12 +25,19 @@ EXTRA_DIST = domainsnobypass.in \
 install-data-local: 
 	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
 		for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+	done && \
+		for l in exceptionvirusextensionlist exceptionvirussiteiplist ; do \
+			if test -f contentscanners/$$l ; then \
+				echo "$(INSTALL_DATA) contentscanners/$$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+				$(INSTALL_DATA) contentscanners/$$l $(DESTDIR)$(E2DATADIR)/$$l; \
+			fi; \
 	done
-
-
 uninstall-local:
 	for l in $(WLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
+	done
+	for l in exceptionvirusextensionlist exceptionvirussiteiplist ; do \
 		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
 	done

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -5,7 +5,8 @@ E2DATADIR = $(E2CONFDIR)/lists/contentscanners
 SUBDIRS = .
 
 WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
-         exceptionvirussitelist exceptionvirusurllist
+         exceptionvirussitelist exceptionvirusurllist \
+         exceptionvirussiteiplist
 
 EXTRA_DIST = $(WLISTS)
 

--- a/configs/lists/contentscanners/exceptionvirussiteiplist
+++ b/configs/lists/contentscanners/exceptionvirussiteiplist
@@ -1,0 +1,11 @@
+# IP sites in exceptionvirussiteiplist
+#
+# The exceptionvirussiteiplist is for allowing ALL of an IP site
+# when using content scanners that would otherwise block it.
+#
+# IP site addresses
+#
+# Single IPs, ranges and subnets can be used, for example:
+# 192.168.0.1
+# 10.0.0.1-10.0.0.3
+# 10.0.0.0/24


### PR DESCRIPTION
## Summary
- copy the contentscanner exception lists into the top-level lists directory during installation so downstream packaging scripts can relocate them
- add the missing exceptionvirussiteiplist template and ensure it is installed alongside the other contentscanner lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f144b11f34832e91dc5e745393c21d