### PR TITLE
Garantir instalação dos arquivos sample esperados pelo port FreeBSD

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -10,20 +10,20 @@ SUBDIRS += contentscanners
 endif
 
 FLISTS = e2guardian.conf e2guardianf1.conf examplef1.story common.story \
-	site.story preauth.story
+        site.story preauth.story
 
 EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in 
 
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2CONFDIR) && \
-	for l in $(FLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2CONFDIR) && \
+        for l in $(FLISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
+        done
 
 uninstall-local:
-	for l in $(FLISTS) ; do \
-		rm -f $(DESTDIR)$(E2CONFDIR)/$$l ; \
-	done
+        for l in $(FLISTS) ; do \
+                rm -f $(DESTDIR)$(E2CONFDIR)/$$l.sample ; \
+        done
 

--- a/configs/authplugins/Makefile.am
+++ b/configs/authplugins/Makefile.am
@@ -5,7 +5,7 @@ E2DATADIR = $(E2CONFDIR)/authplugins
 SUBDIRS = .
 
 FLISTS = proxy-basic.conf ident.conf ip.conf proxy-digest.conf \
-	 port.conf pf-basic.conf
+         port.conf pf-basic.conf proxy-header.conf
 
 if ENABLE_NTLM
 FLISTS += proxy-ntlm.conf
@@ -17,17 +17,17 @@ endif
 
 
 EXTRA_DIST = proxy-basic.conf ident.conf ip.conf proxy-ntlm.conf \
-	     proxy-digest.conf port.conf dnsauth.conf
+             proxy-digest.conf port.conf dnsauth.conf proxy-header.conf
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(FLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+        for l in $(FLISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(FLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(FLISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/downloadmanagers/Makefile.am
+++ b/configs/downloadmanagers/Makefile.am
@@ -11,15 +11,15 @@ FLISTS = default.conf
 
 EXTRA_DIST = default.conf.in 
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(FLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+        for l in $(FLISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(FLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(FLISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -13,31 +13,25 @@ if NEED_DMLISTS
 SUBDIRS += downloadmanagers
 endif
 
-WLISTS = README \
-        domainsnobypass \
+SAMPLELISTS = domainsnobypass \
         ipnobypass \
-        urlnobypass
+        urlnobypass \
+        newbannedphraselist \
+        newexceptionphraselist \
+        newweightedphraselist
 
 EXTRA_DIST = domainsnobypass.in \
              ipnobypass \
              urlnobypass.in
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-		for l in $(WLISTS) ; do \
-			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done && \
-		for l in exceptionvirusextensionlist exceptionvirussiteiplist ; do \
-			if test -f contentscanners/$$l ; then \
-				echo "$(INSTALL_DATA) contentscanners/$$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-				$(INSTALL_DATA) contentscanners/$$l $(DESTDIR)$(E2DATADIR)/$$l; \
-			fi; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+                for l in $(SAMPLELISTS) ; do \
+                        echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                        $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
+
 uninstall-local:
-	for l in $(WLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
-	for l in exceptionvirusextensionlist exceptionvirussiteiplist ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(SAMPLELISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/authplugins/Makefile.am
+++ b/configs/lists/authplugins/Makefile.am
@@ -8,15 +8,15 @@ WLISTS = ipgroups portgroups filtergroupslist
 
 EXTRA_DIST = $(WLISTS)
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+        for l in $(WLISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(WLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(WLISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/bannedrooms/Makefile.am
+++ b/configs/lists/bannedrooms/Makefile.am
@@ -8,15 +8,15 @@ WLISTS = default
 
 EXTRA_DIST = $(WLISTS)
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+        for l in $(WLISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(WLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(WLISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -1,10 +1,10 @@
 DISTCLEANFILES = Makefile.in 
 
-E2DATADIR = $(E2CONFDIR)/lists/common
+E2DATADIR = $(E2CONFDIR)/lists
 
-SUBDIRS = . 
+SUBDIRS = .
 
-WLISTS = authexceptioniplist \
+SAMPLELISTS = authexceptioniplist \
 authexceptionsitelist \
 authexceptionurllist \
 bannedclientlist \
@@ -23,20 +23,19 @@ nologurllist \
 nomitmsiteiplist \
 nomitmsitelist \
 searchregexplist \
-searchexceptionregexplist \
-README
+searchexceptionregexplist
  
 EXTRA_DIST = 
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-		for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+                for l in $(SAMPLELISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(WLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(SAMPLELISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -10,15 +10,15 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 
 EXTRA_DIST = $(WLISTS)
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+        for l in $(WLISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(WLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(WLISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -4,11 +4,11 @@ DISTCLEANFILES = Makefile.in \
 		oldbannedphraselist \
 		oldexceptionphraselist oldweightedphraselist
 
-E2DATADIR = $(E2CONFDIR)/lists/example.group
+E2DATADIR = $(E2CONFDIR)/lists
 
 SUBDIRS = . 
 
-WLISTS = addheaderregexplist \
+SAMPLELISTS = addheaderregexplist \
 bannedsearchoveridelist \
 bannedextensionlist \
 bannedmimetypelist \
@@ -79,8 +79,7 @@ ipnobypass \
 domainsnobypass \
 urlnobypass \
 weightedphraselist \
-oldweightedphraselist \
-README
+oldweightedphraselist
  
 EXTRA_DIST = bannedphraselist.in \
 oldbannedphraselist.in \
@@ -93,15 +92,15 @@ urlnobypass.in \
 weightedphraselist.in \
 oldweightedphraselist.in
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-		for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
-	done
+install-data-local:
+        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+                for l in $(SAMPLELISTS) ; do \
+                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+        done
 
 
 uninstall-local:
-	for l in $(WLISTS) ; do \
-		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
-	done
+        for l in $(SAMPLELISTS) ; do \
+                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+        done

--- a/configs/lists/newbannedphraselist
+++ b/configs/lists/newbannedphraselist
@@ -1,0 +1,3 @@
+# Placeholder for site-specific banned phrases using the new format.
+# Copy or convert your old phraselists into this file as needed.
+# Lines starting with '#' are treated as comments.

--- a/configs/lists/newexceptionphraselist
+++ b/configs/lists/newexceptionphraselist
@@ -1,0 +1,3 @@
+# Placeholder for site-specific exception phrases using the new format.
+# Copy or convert your old phraselists into this file as needed.
+# Lines starting with '#' are treated as comments.

--- a/configs/lists/newweightedphraselist
+++ b/configs/lists/newweightedphraselist
@@ -1,0 +1,3 @@
+# Placeholder for site-specific weighted phrases using the new format.
+# Copy or convert your old phraselists into this file as needed.
+# Lines starting with '#' are treated as comments.

--- a/configs/lists/phraselists/Makefile.am
+++ b/configs/lists/phraselists/Makefile.am
@@ -22,34 +22,61 @@ MYSUBDIRS = chinesebig5 chinesegb2312 danish dutch french german italian japanes
 #	done
 
 PHRASELISTS = badwords chat drugadvocacy gambling games goodphrases \
-		gore illegaldrugs intolerance \
-		nudism personals pornography \
-		proxies violence warezhacking weapons 
-		
+                gore illegaldrugs intolerance \
+                nudism personals pornography \
+                proxies violence warezhacking weapons
 
-install-data-local: 
-	for lang in $(MYSUBDIRS); do \
-	for l in $(PHRASELISTS); do \
-		if test -d $(srcdir)/$$lang/$$l ; then \
-		$(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$lang/$$l && \
+COMPAT_DIRS = badwords chat conspiracy domainsforsale drugadvocacy \
+                forums gambling games goodphrases googlesearches gore \
+                illegaldrugs intolerance legaldrugs malware music news \
+                nudism peer2peer personals pornography proxies rta \
+                safelabel secretsocieties sport translation travel \
+                upstreamfilter violence warezhacking weapons webmail \
+                idtheft
+
+install-data-local:
+        for lang in $(MYSUBDIRS); do \
+        for l in $(PHRASELISTS); do \
+                if test -d $(srcdir)/$$lang/$$l ; then \
+                $(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$lang/$$l && \
 		for f in $(srcdir)/$$lang/$$l/weighted* $(srcdir)/$$lang/$$l/exception* $(srcdir)/$$lang/$$l/banned*; do \
 		   if test -f $$f ; then \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$lang/$$l"; \
 			$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$lang/$$l; \
 	           fi \
 		done \
-		fi \
-	done \
-	done 
+                fi \
+        done \
+        done
+        for compat in $(COMPAT_DIRS); do \
+                if test -d $(srcdir)/../oldphraselists/$$compat ; then \
+                        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$compat && \
+                        for f in $(srcdir)/../oldphraselists/$$compat/weighted* \
+                                 $(srcdir)/../oldphraselists/$$compat/exception* \
+                                 $(srcdir)/../oldphraselists/$$compat/banned*; do \
+                                if test -f $$f ; then \
+                                        echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$compat/`basename $$f`"; \
+                                        $(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$compat/`basename $$f`; \
+                                fi \
+                        done \
+                fi \
+        done
 
 uninstall-local:
-	for lang in $(MYSUBDIRS); do \
-	for l in $(PHRASELISTS); do \
-		for f in $(srcdir)/$$lang/$$l/weighted* $(srcdir)/$$lang/$$l/exception*; do \
-	        	rm -f $(DESTDIR)$(E2DATADIR)/$$lang/$$l/`basename $$f`; \
-		done \
-	done \
-	done
+        for lang in $(MYSUBDIRS); do \
+        for l in $(PHRASELISTS); do \
+                for f in $(srcdir)/$$lang/$$l/weighted* $(srcdir)/$$lang/$$l/exception*; do \
+                        rm -f $(DESTDIR)$(E2DATADIR)/$$lang/$$l/`basename $$f`; \
+                done \
+        done \
+        done
+        for compat in $(COMPAT_DIRS); do \
+                for f in $(srcdir)/../oldphraselists/$$compat/weighted* \
+                         $(srcdir)/../oldphraselists/$$compat/exception* \
+                         $(srcdir)/../oldphraselists/$$compat/banned*; do \
+                        rm -f $(DESTDIR)$(E2DATADIR)/$$compat/`basename $$f`; \
+                done \
+        done
 
 dist-hook:
 	for lang in $(MYSUBDIRS); do \


### PR DESCRIPTION
## Summary
- ajustar as regras de instalação para que todos os arquivos de configuração sejam copiados com a extensão `.sample`
- adicionar listas em branco para os novos arquivos `new*banned/exception/weighted` exigidos pelo port
- copiar automaticamente as antigas phraselists para o layout legado utilizado pelo pacote de gerenciamento

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f148b7373c832e9812d7f8378078bc