### PR TITLE
Fix configs Makefile indentation for FreeBSD make

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -16,14 +16,14 @@ EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in
 
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2CONFDIR) && \
-        for l in $(FLISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2CONFDIR) && \
+	for l in $(FLISTS) ; do \
+	echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
+	$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
+	done
 
 uninstall-local:
-        for l in $(FLISTS) ; do \
-                rm -f $(DESTDIR)$(E2CONFDIR)/$$l.sample ; \
-        done
+	for l in $(FLISTS) ; do \
+	rm -f $(DESTDIR)$(E2CONFDIR)/$$l.sample ; \
+	done
 


### PR DESCRIPTION
## Summary
- replace space-indented recipe lines in configs/Makefile.am with tab-indented lines so BSD make recognizes them as commands

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f14d4dc178832eb6453d75616e7384