### PR TITLE
Fix FreeBSD make compatibility for sample list recipes

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -25,13 +25,13 @@ EXTRA_DIST = domainsnobypass.in \
              urlnobypass.in
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-                for l in $(SAMPLELISTS) ; do \
-                        echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                        $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(SAMPLELISTS) ; do \
+	echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+	$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 uninstall-local:
-        for l in $(SAMPLELISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(SAMPLELISTS) ; do \
+	rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done


### PR DESCRIPTION
## Summary
- ensure recipe lines in configs/lists/Makefile.am use tabs so BSD make parses them correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f14e6cc904832eb93ab2e86c416318