### PR TITLE
Fix Makefile recipes for BSD make

### DIFF
--- a/configs/authplugins/Makefile.am
+++ b/configs/authplugins/Makefile.am
@@ -20,14 +20,14 @@ EXTRA_DIST = proxy-basic.conf ident.conf ip.conf proxy-ntlm.conf \
              proxy-digest.conf port.conf dnsauth.conf proxy-header.conf
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-        for l in $(FLISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(FLISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(FLISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(FLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done

--- a/configs/downloadmanagers/Makefile.am
+++ b/configs/downloadmanagers/Makefile.am
@@ -12,14 +12,14 @@ FLISTS = default.conf
 EXTRA_DIST = default.conf.in 
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-        for l in $(FLISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(FLISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(FLISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(FLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done

--- a/configs/lists/authplugins/Makefile.am
+++ b/configs/lists/authplugins/Makefile.am
@@ -9,14 +9,14 @@ WLISTS = ipgroups portgroups filtergroupslist
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-        for l in $(WLISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(WLISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(WLISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(WLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done

--- a/configs/lists/bannedrooms/Makefile.am
+++ b/configs/lists/bannedrooms/Makefile.am
@@ -9,14 +9,14 @@ WLISTS = default
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-        for l in $(WLISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(WLISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(WLISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(WLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -28,14 +28,14 @@ searchexceptionregexplist
 EXTRA_DIST = 
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-                for l in $(SAMPLELISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(SAMPLELISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(SAMPLELISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(SAMPLELISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -11,14 +11,14 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-        for l in $(WLISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(WLISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(WLISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(WLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -93,14 +93,14 @@ weightedphraselist.in \
 oldweightedphraselist.in
 
 install-data-local:
-        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-                for l in $(SAMPLELISTS) ; do \
-                echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-                $(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
-        done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(SAMPLELISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	done
 
 
 uninstall-local:
-        for l in $(SAMPLELISTS) ; do \
-                rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
-        done
+	for l in $(SAMPLELISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \
+	done


### PR DESCRIPTION
## Summary
- replace space-indented recipe lines in configuration Makefile.am files with tab-indented commands so BSD make accepts them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1520b1f18832e853ef7c9b39bf9ea