### PR TITLE
Ensure authplugin lists install default files

### DIFF
--- a/configs/lists/authplugins/Makefile.am
+++ b/configs/lists/authplugins/Makefile.am
@@ -13,6 +13,10 @@ install-data-local:
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+		fi; \
 	done
 
 


### PR DESCRIPTION
## Summary
- install default authplugin list files when staging configuration samples
- ensure packaging scripts that rename configuration files find expected sources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1545f15a8832eaef7edbf5b3bebf4