### PR TITLE
Ensure bannedrooms default list installed during make install

### DIFF
--- a/configs/lists/bannedrooms/Makefile.am
+++ b/configs/lists/bannedrooms/Makefile.am
@@ -13,6 +13,10 @@ install-data-local:
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+		fi; \
 	done
 
 


### PR DESCRIPTION
## Summary
- ensure the bannedrooms list install target also copies the default list when it is missing so ports scripts can rename it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f1569b054c832e96e07b7844308121