### PR TITLE
Ensure list files are installed before sample copies

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -25,12 +25,15 @@ EXTRA_DIST = domainsnobypass.in \
              urlnobypass.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(SAMPLELISTS) ; do \
-	echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-	$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	for l in $(SAMPLELISTS) ; do \\
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
+		fi; \\
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
 	done
-
 uninstall-local:
 	for l in $(SAMPLELISTS) ; do \
 	rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -28,13 +28,15 @@ searchexceptionregexplist
 EXTRA_DIST = 
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(SAMPLELISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	for l in $(SAMPLELISTS) ; do \\
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
+		fi; \\
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
 	done
-
-
 uninstall-local:
 	for l in $(SAMPLELISTS) ; do \
 		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -11,13 +11,15 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(WLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	for l in $(WLISTS) ; do \\
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
+		fi; \\
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
 	done
-
-
 uninstall-local:
 	for l in $(WLISTS) ; do \
 		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -93,13 +93,15 @@ weightedphraselist.in \
 oldweightedphraselist.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
-	for l in $(SAMPLELISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	for l in $(SAMPLELISTS) ; do \\
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
+		fi; \\
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
 	done
-
-
 uninstall-local:
 	for l in $(SAMPLELISTS) ; do \
 		rm -f $(DESTDIR)$(E2DATADIR)/$$l.sample ; \


### PR DESCRIPTION
## Summary
- ensure each lists Makefile installs the default list file when missing before writing the .sample copy
- cover the main lists directory, the shared common lists, the example group lists, and contentscanner lists so ports have real files to rename

## Testing
- not run (install-time makefile changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f158f020f0832e849d17dd53ab0419