### PR TITLE
Fix shell loops in list installation targets

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -25,7 +25,7 @@ EXTRA_DIST = domainsnobypass.in \
              urlnobypass.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -28,7 +28,7 @@ searchexceptionregexplist
 EXTRA_DIST = 
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -11,7 +11,7 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(WLISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -93,7 +93,7 @@ weightedphraselist.in \
 oldweightedphraselist.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\


### PR DESCRIPTION
## Summary
- terminate the mkinstalldirs command in install-data recipes before running the loop
- ensure multiple list Makefile.am files separate directory creation from the subsequent for-loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f15b39a5bc832e8dd412c3710fbe7e