### PR TITLE
Fix indentation issues flagged by FreeBSD build

### DIFF
--- a/src/Auth.cpp
+++ b/src/Auth.cpp
@@ -75,30 +75,30 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     String lastcategory;
     u.toLower(); // since the filtergroupslist is read in in lowercase, we should do this.
     user = u.toCharArray(); // also pass back to ConnectionHandler, so appears lowercase in logs
-  //  String ue(u);
-  //  ue += "=";
+    //  String ue(u);
+    //  ue += "=";
 
     //char *i = ldl->filter_groups_list.findStartsWithPartial(ue.toCharArray(), lastcategory);
- //   char *i = uglc.findStartsWithPartial(ue.toCharArray(), lastcategory);
-     cm.user = user;
-     if (!story.runFunctEntry(story_entry,cm)) {
-         int t = get_default(!cm.request_header->isProxyRequest);
-         if (t > 0) {
-             fg = --t;
-             cm.authrec->group_source = "pdef";
-             return E2AUTH_OK;
-         }
+    //   char *i = uglc.findStartsWithPartial(ue.toCharArray(), lastcategory);
+    cm.user = user;
+    if (!story.runFunctEntry(story_entry, cm)) {
+        int t = get_default(!cm.request_header->isProxyRequest);
+        if (t > 0) {
+            fg = --t;
+            cm.authrec->group_source = "pdef";
+            return E2AUTH_OK;
+        }
 #ifdef E2DEBUG
-             std::cerr << "User not in filter groups list for: " << pluginName.c_str() << std::endl;
+        std::cerr << "User not in filter groups list for: " << pluginName.c_str() << std::endl;
 #endif
-             return E2AUTH_NOGROUP;
-      }
+        return E2AUTH_NOGROUP;
+    }
 
 #ifdef E2DEBUG
     std::cerr << "Group found for: " << user.c_str() << " in " << pluginName.c_str() << std::endl;
 #endif
-     fg = cm.filtergroup;
-     return E2AUTH_OK;
+    fg = cm.filtergroup;
+    return E2AUTH_OK;
 }
 
 // take in a configuration file, find the AuthPlugin class associated with the plugname variable, and return an instance

--- a/src/ConfigVar.cpp
+++ b/src/ConfigVar.cpp
@@ -23,7 +23,7 @@ ConfigVar::ConfigVar()
 // construct & read in the given config file
 ConfigVar::ConfigVar(const char *filename, const char *delimiter)
 {
-   readVar(filename, delimiter);
+    readVar(filename, delimiter);
 }
 
 // return the value for the named option

--- a/src/FDFuncs.cpp
+++ b/src/FDFuncs.cpp
@@ -36,7 +36,7 @@ int readEINTR(int fd, char *buf, unsigned int count)
 // wrapper around FD write that restarts on EINTR
 int writeEINTR(int fd, char *buf, unsigned int count)
 {
-return write(fd, buf, count);
+    return write(fd, buf, count);
 //    int rc;
 //    errno = 0;
 //    while (true) { // using the while as a restart point with continue

--- a/src/FOptionContainer.cpp
+++ b/src/FOptionContainer.cpp
@@ -468,8 +468,8 @@ bool FOptionContainer::read(const char *filename) {
         }
         if (reporting_level == 3) {
             if (access_denied_domain.length() > 1) {
-             	if (!is_daemonised) {
-                       std::cerr << thread_id << "Warning accessdeniedaddress setting appears to be wrong in reportinglevel 3" << std::endl;
+                if (!is_daemonised) {
+                    std::cerr << thread_id << "Warning accessdeniedaddress setting appears to be wrong in reportinglevel 3" << std::endl;
                 }
                 syslog(LOG_ERR, "%s", "Warning accessdeniedaddress setting appears to be wrong in reportinglevel 3");
                 return false;

--- a/src/StoryBoard.cpp
+++ b/src/StoryBoard.cpp
@@ -447,7 +447,7 @@ bool StoryBoard::runFunct(unsigned int fID, NaughtyFilter &cm) {
             case SB_STATE_EXTENSIONIN:
                 target = cm.response_header->disposition();
                 if (target.length() > 4)
-                     isListCheck = true;
+                    isListCheck = true;
                 target2 = "";
                 break;
             case SB_STATE_MIMEIN:


### PR DESCRIPTION
## Summary
- normalize indentation in the Auth plugin group resolution logic
- fix misaligned indentation in ConfigVar, FDFuncs, StoryBoard, and reporting-level checks
- improve consistency in warning messages to silence FreeBSD indentation complaints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f15c1171a8832e930311b1171fc08d