### PR TITLE
Fix install-data-local command termination

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -25,14 +25,14 @@ EXTRA_DIST = domainsnobypass.in \
              urlnobypass.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
-	for l in $(SAMPLELISTS) ; do \\
-		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
-			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
-			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
-		fi; \\
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR)
+	for l in $(SAMPLELISTS) ; do \
+		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+		fi; \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
 	done
 uninstall-local:
 	for l in $(SAMPLELISTS) ; do \


### PR DESCRIPTION
## Summary
- remove the trailing command separator from the install-data-local rule so the shell does not try to execute a bare backslash
- keep the loop logic but rely on separate lines for the directory creation step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f15e8742f0832e912d0ad05d9c3f4d