### PR TITLE
Fix install-data directory creation commands

### DIFF
--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -28,7 +28,7 @@ searchexceptionregexplist
 EXTRA_DIST = 
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -11,7 +11,7 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \\
 	for l in $(WLISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -93,7 +93,7 @@ weightedphraselist.in \
 oldweightedphraselist.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR); \\
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\


### PR DESCRIPTION
## Summary
- ensure list install targets chain directory creation with `&&` so the for-loop executes
- apply the same fix to the common, contentscanners, and example group list makefiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f1604fa540832e84e7c062bbf6ccb7