### PR TITLE
Fix install directory creation for FreeBSD shells

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -1,7 +1,7 @@
 DISTCLEANFILES = Makefile.in \
 e2guardian.conf \
 e2guardianf1.conf \
-examplef1.story 
+examplef1.story
 
 SUBDIRS = lists downloadmanagers authplugins .
 
@@ -12,14 +12,14 @@ endif
 FLISTS = e2guardian.conf e2guardianf1.conf examplef1.story common.story \
         site.story preauth.story
 
-EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in 
+EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in
 
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2CONFDIR) && \
+	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR); \\
 	for l in $(FLISTS) ; do \
-	echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
-	$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
 	done
 
 uninstall-local:

--- a/configs/authplugins/Makefile.am
+++ b/configs/authplugins/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST = proxy-basic.conf ident.conf ip.conf proxy-ntlm.conf \
              proxy-digest.conf port.conf dnsauth.conf proxy-header.conf
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/contentscanners/Makefile.am
+++ b/configs/contentscanners/Makefile.am
@@ -7,7 +7,7 @@ E2DATADIR = $(E2CONFDIR)/contentscanners
 SUBDIRS = .
 
 
-FLISTS = 
+FLISTS =
 
 if ENABLE_CLAMD
 FLISTS += clamdscan.conf
@@ -32,8 +32,8 @@ endif
 EXTRA_DIST = clamdscan.conf.in avastdscan.conf.in icapscan.conf.in \
              kavdscan.conf.in commandlinescan.conf.in
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \

--- a/configs/downloadmanagers/Makefile.am
+++ b/configs/downloadmanagers/Makefile.am
@@ -1,5 +1,5 @@
 DISTCLEANFILES = Makefile.in \
-		       default.conf 
+		       default.conf
 
 E2DATADIR = $(E2CONFDIR)/downloadmanagers
 
@@ -9,10 +9,10 @@ FLISTS = default.conf
 
 
 
-EXTRA_DIST = default.conf.in 
+EXTRA_DIST = default.conf.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -25,7 +25,7 @@ EXTRA_DIST = domainsnobypass.in \
              urlnobypass.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR)
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR)
 	for l in $(SAMPLELISTS) ; do \
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \

--- a/configs/lists/authplugins/Makefile.am
+++ b/configs/lists/authplugins/Makefile.am
@@ -9,7 +9,7 @@ WLISTS = ipgroups portgroups filtergroupslist
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/lists/bannedrooms/Makefile.am
+++ b/configs/lists/bannedrooms/Makefile.am
@@ -9,7 +9,7 @@ WLISTS = default
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -1,4 +1,4 @@
-DISTCLEANFILES = Makefile.in 
+DISTCLEANFILES = Makefile.in
 
 E2DATADIR = $(E2CONFDIR)/lists
 
@@ -24,11 +24,11 @@ nomitmsiteiplist \
 nomitmsitelist \
 searchregexplist \
 searchexceptionregexplist
- 
-EXTRA_DIST = 
+
+EXTRA_DIST =
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -11,7 +11,7 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(WLISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/downloadmanagers/Makefile.am
+++ b/configs/lists/downloadmanagers/Makefile.am
@@ -8,8 +8,8 @@ WLISTS = managedmimetypelist managedextensionlist
 
 EXTRA_DIST = $(WLISTS)
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -6,7 +6,7 @@ DISTCLEANFILES = Makefile.in \
 
 E2DATADIR = $(E2CONFDIR)/lists
 
-SUBDIRS = . 
+SUBDIRS = .
 
 SAMPLELISTS = addheaderregexplist \
 bannedsearchoveridelist \
@@ -80,7 +80,7 @@ domainsnobypass \
 urlnobypass \
 weightedphraselist \
 oldweightedphraselist
- 
+
 EXTRA_DIST = bannedphraselist.in \
 oldbannedphraselist.in \
 bannedsitelist.in \
@@ -93,7 +93,7 @@ weightedphraselist.in \
 oldweightedphraselist.in
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 	for l in $(SAMPLELISTS) ; do \\
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\

--- a/configs/lists/oldphraselists/Makefile.am
+++ b/configs/lists/oldphraselists/Makefile.am
@@ -8,9 +8,9 @@ PHRASELISTS = badwords chat drugadvocacy gambling games goodphrases \
 		forums rta conspiracy domainsforsale idtheft safelabel \
 		travel upstreamfilter secretsocieties translation music
 
-install-data-local: 
+install-data-local:
 	for l in $(PHRASELISTS); do \
-		$(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$l && \
+		$(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$l; \\
 		for f in $(srcdir)/$$l/weighted* $(srcdir)/$$l/exception* $(srcdir)/$$l/banned*; do \
 		   if test -f $$f ; then \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$l"; \
@@ -38,4 +38,4 @@ dist-hook:
 	      fi; \
 	    done; \
 	  fi; \
-	done		
+	done

--- a/configs/lists/phraselists/Makefile.am
+++ b/configs/lists/phraselists/Makefile.am
@@ -1,15 +1,15 @@
-DISTCLEANFILES = Makefile.in 
+DISTCLEANFILES = Makefile.in
 
 E2DATADIR = $(E2CONFDIR)/lists/phraselists
 
-MYSUBDIRS = chinesebig5 chinesegb2312 danish dutch french german italian japanese malay norwegian polish portuguese russian-1251 russian-koi8-r spanish swedish ukenglish 
+MYSUBDIRS = chinesebig5 chinesegb2312 danish dutch french german italian japanese malay norwegian polish portuguese russian-1251 russian-koi8-r spanish swedish ukenglish
 
 
 #WLISTS = README
- 
 
-#install-data-local: 
-#	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+
+#install-data-local:
+#	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
 #		for l in $(WLISTS) ; do \
 #		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 #		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
@@ -38,7 +38,7 @@ install-data-local:
 	for lang in $(MYSUBDIRS); do \
 	for l in $(PHRASELISTS); do \
 	        if test -d $(srcdir)/$$lang/$$l ; then \
-	        $(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$lang/$$l && \
+	        $(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$lang/$$l; \\
 		for f in $(srcdir)/$$lang/$$l/weighted* $(srcdir)/$$lang/$$l/exception* $(srcdir)/$$lang/$$l/banned*; do \
 		   if test -f $$f ; then \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$lang/$$l"; \
@@ -50,7 +50,7 @@ install-data-local:
 	done
 	for compat in $(COMPAT_DIRS); do \
 	        if test -d $(srcdir)/../oldphraselists/$$compat ; then \
-	                $(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$compat && \
+	                $(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$compat; \\
 	                for f in $(srcdir)/../oldphraselists/$$compat/weighted* \
 	                         $(srcdir)/../oldphraselists/$$compat/exception* \
 	                         $(srcdir)/../oldphraselists/$$compat/banned*; do \
@@ -92,6 +92,6 @@ dist-hook:
 	    done; \
 	  fi; \
 	done \
-	done		
+	done
 
 

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -9,9 +9,9 @@ FLISTS = transparent1x1.gif e2guardian.pl blockedflash.swf
 EXTRA_DIST = $(FLISTS)
 
 install-data-local:
-	$(mkinstalldirs) $(DESTDIR)$(DATATOPDIR) && \
-	$(mkinstalldirs) $(DESTDIR)$(E2LOGLOCATION) && \
-	$(mkinstalldirs) $(DESTDIR)$(E2PIDDIR) && \
+	$(MKDIR_P) $(DESTDIR)$(DATATOPDIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2LOGLOCATION); \\
+	$(MKDIR_P) $(DESTDIR)$(E2PIDDIR); \\
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l; \

--- a/data/languages/Makefile.am
+++ b/data/languages/Makefile.am
@@ -10,9 +10,9 @@ LANGUAGES = 	czech   hebrew      turkish \
 
 EXTRA_DIST= ReadMe
 
-install-data-local: 
+install-data-local:
 	@for l in $(LANGUAGES); do \
-		$(mkinstalldirs) $(DESTDIR)$(LANGDIR)/$$l && \
+		$(MKDIR_P) $(DESTDIR)$(LANGDIR)/$$l; \\
 		for f in $(srcdir)/$$l/messages $(srcdir)/$$l/template.html $(srcdir)/$$l/neterr_template.html $(srcdir)/$$l/fancydmtemplate.html; do \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(LANGDIR)/$$l"; \
 			$(INSTALL_DATA) $$f $(DESTDIR)$(LANGDIR)/$$l; \
@@ -35,4 +35,4 @@ dist-hook:
 	    cp -p $(srcdir)/$$lang/messages $(srcdir)/$$lang/template.html $(srcdir)/$$l/neterr_template.html $(srcdir)/$$lang/fancydmtemplate.html $(distdir)/$$lang \
 	      || exit 1; \
 	  fi; \
-	done		
+	done

--- a/data/scripts/Makefile.am
+++ b/data/scripts/Makefile.am
@@ -6,14 +6,14 @@ DATATOPDIR = $(datadir)/$(PACKAGE_NAME)/scripts
 
 FLISTS = e2guardian logrotation bsd-init\
              solaris-init systemv-init\
-	     e2guardian.service 
+	     e2guardian.service
 
 EXTRA_DIST = e2guardian.in logrotation.in bsd-init.in\
              solaris-init.in systemv-init.in\
-	     e2guardian.service.in 
+	     e2guardian.service.in
 
-install-data-local: 
-	$(mkinstalldirs) $(DESTDIR)$(DATATOPDIR) && \
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(DATATOPDIR); \\
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l; \


### PR DESCRIPTION
## Summary
- replace uses of $(mkinstalldirs) with $(MKDIR_P) in install recipes so the shell never tries to execute a bare backslash on FreeBSD
- keep the installation loops intact by terminating the directory creation lines with `; \` rather than `&& \`

## Testing
- not run (FreeBSD-specific change)


------
https://chatgpt.com/codex/tasks/task_e_68f161f3a25c832ebf185ce6eed8a2c5