### PR TITLE
Fix language data install loops for FreeBSD build

### DIFF
--- a/data/languages/Makefile.am
+++ b/data/languages/Makefile.am
@@ -12,19 +12,19 @@ EXTRA_DIST= ReadMe
 
 install-data-local:
 	@for l in $(LANGUAGES); do \
-		$(MKDIR_P) $(DESTDIR)$(LANGDIR)/$$l; \\
+		$(MKDIR_P) $(DESTDIR)$(LANGDIR)/$$l; \
 		for f in $(srcdir)/$$l/messages $(srcdir)/$$l/template.html $(srcdir)/$$l/neterr_template.html $(srcdir)/$$l/fancydmtemplate.html; do \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(LANGDIR)/$$l"; \
 			$(INSTALL_DATA) $$f $(DESTDIR)$(LANGDIR)/$$l; \
-		done \
-	done
+			done; \
+		done
 
 uninstall-local:
 	@for l in $(LANGUAGES); do \
 		for f in $(srcdir)/$$l/messages $(srcdir)/$$l/template.html $(srcdir)/$$l/neterr_template.html $(srcdir)/$$l/fancydmtemplate.html; do \
-	        	rm -f $(DESTDIR)$(LANGDIR)/$$l/`basename $$f`; \
-		done \
-	done
+			rm -f $(DESTDIR)$(LANGDIR)/$$l/`basename $$f`; \
+			done; \
+		done
 
 dist-hook:
 	@ for lang in $(LANGUAGES); do \
@@ -32,7 +32,7 @@ dist-hook:
 	    test -d $(distdir)/$$lang \
 	    || mkdir $(distdir)/$$lang \
 	    || exit 1; \
-	    cp -p $(srcdir)/$$lang/messages $(srcdir)/$$lang/template.html $(srcdir)/$$l/neterr_template.html $(srcdir)/$$lang/fancydmtemplate.html $(distdir)/$$lang \
+	    cp -p $(srcdir)/$$lang/messages $(srcdir)/$$lang/template.html $(srcdir)/$$lang/neterr_template.html $(srcdir)/$$lang/fancydmtemplate.html $(distdir)/$$lang \
 	      || exit 1; \
 	  fi; \
 	done


### PR DESCRIPTION
## Summary
- add explicit loop terminators in the language install and uninstall recipes so /bin/sh can execute them during packaging
- copy the language neterr template from the correct directory when building a distribution tarball

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f16602325c832e9bd07f0caa3ddd5b