### PR TITLE
Fix data install recipes to avoid stray backslash commands

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -9,9 +9,9 @@ FLISTS = transparent1x1.gif e2guardian.pl blockedflash.swf
 EXTRA_DIST = $(FLISTS)
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(DATATOPDIR); \\
-	$(MKDIR_P) $(DESTDIR)$(E2LOGLOCATION); \\
-	$(MKDIR_P) $(DESTDIR)$(E2PIDDIR); \\
+	$(MKDIR_P) $(DESTDIR)$(DATATOPDIR)
+	$(MKDIR_P) $(DESTDIR)$(E2LOGLOCATION)
+	$(MKDIR_P) $(DESTDIR)$(E2PIDDIR)
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l; \

--- a/data/scripts/Makefile.am
+++ b/data/scripts/Makefile.am
@@ -13,7 +13,7 @@ EXTRA_DIST = e2guardian.in logrotation.in bsd-init.in\
 	     e2guardian.service.in
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(DATATOPDIR); \\
+	$(MKDIR_P) $(DESTDIR)$(DATATOPDIR)
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(DATATOPDIR)/$$l; \


### PR DESCRIPTION
## Summary
- remove trailing backslashes from the install-data-local recipes in data and scripts
- ensure the mkdir commands run as separate shell lines to avoid `\` execution errors during install

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f167b6e048832eba30b4487aaee8a3