### PR TITLE
Fix line continuations in Makefile loops

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in
 
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR); \
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \

--- a/configs/authplugins/Makefile.am
+++ b/configs/authplugins/Makefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST = proxy-basic.conf ident.conf ip.conf proxy-ntlm.conf \
              proxy-digest.conf port.conf dnsauth.conf proxy-header.conf
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/contentscanners/Makefile.am
+++ b/configs/contentscanners/Makefile.am
@@ -33,7 +33,7 @@ EXTRA_DIST = clamdscan.conf.in avastdscan.conf.in icapscan.conf.in \
              kavdscan.conf.in commandlinescan.conf.in
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \

--- a/configs/downloadmanagers/Makefile.am
+++ b/configs/downloadmanagers/Makefile.am
@@ -12,7 +12,7 @@ FLISTS = default.conf
 EXTRA_DIST = default.conf.in
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/lists/authplugins/Makefile.am
+++ b/configs/lists/authplugins/Makefile.am
@@ -9,7 +9,7 @@ WLISTS = ipgroups portgroups filtergroupslist
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/lists/bannedrooms/Makefile.am
+++ b/configs/lists/bannedrooms/Makefile.am
@@ -9,7 +9,7 @@ WLISTS = default
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -28,14 +28,14 @@ searchexceptionregexplist
 EXTRA_DIST =
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
-	for l in $(SAMPLELISTS) ; do \\
-		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
-			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
-			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
-		fi; \\
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
+        for l in $(SAMPLELISTS) ; do \
+                if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+		fi; \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
 	done
 uninstall-local:
 	for l in $(SAMPLELISTS) ; do \

--- a/configs/lists/contentscanners/Makefile.am
+++ b/configs/lists/contentscanners/Makefile.am
@@ -11,14 +11,14 @@ WLISTS = exceptionvirusmimetypelist exceptionvirusextensionlist \
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
-	for l in $(WLISTS) ; do \\
-		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
-			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
-			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
-		fi; \\
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
+        for l in $(WLISTS) ; do \
+                if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+		fi; \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
 	done
 uninstall-local:
 	for l in $(WLISTS) ; do \

--- a/configs/lists/downloadmanagers/Makefile.am
+++ b/configs/lists/downloadmanagers/Makefile.am
@@ -9,7 +9,7 @@ WLISTS = managedmimetypelist managedextensionlist
 EXTRA_DIST = $(WLISTS)
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 	for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \

--- a/configs/lists/example.group/Makefile.am
+++ b/configs/lists/example.group/Makefile.am
@@ -93,14 +93,14 @@ weightedphraselist.in \
 oldweightedphraselist.in
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
-	for l in $(SAMPLELISTS) ; do \\
-		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \\
-			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \\
-			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \\
-		fi; \\
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \\
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \\
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
+        for l in $(SAMPLELISTS) ; do \
+                if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+			$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+		fi; \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
 	done
 uninstall-local:
 	for l in $(SAMPLELISTS) ; do \

--- a/configs/lists/oldphraselists/Makefile.am
+++ b/configs/lists/oldphraselists/Makefile.am
@@ -10,7 +10,7 @@ PHRASELISTS = badwords chat drugadvocacy gambling games goodphrases \
 
 install-data-local:
 	for l in $(PHRASELISTS); do \
-		$(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$l; \\
+		$(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$l; \
 		for f in $(srcdir)/$$l/weighted* $(srcdir)/$$l/exception* $(srcdir)/$$l/banned*; do \
 		   if test -f $$f ; then \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$l"; \
@@ -33,8 +33,8 @@ dist-hook:
 	    || mkdir $(distdir)/$$phrase \
 	    || exit 1; \
 	    for f in $(srcdir)/$$phrase/weighted* $(srcdir)/$$phrase/banned* $(srcdir)/$$phrase/exception*; do \
-	      if test -f $$f ; then \
-	        cp -p $$f $(distdir)/$$phrase ;\
+              if test -f $$f ; then \
+                cp -p $$f $(distdir)/$$phrase ; \
 	      fi; \
 	    done; \
 	  fi; \

--- a/configs/lists/phraselists/Makefile.am
+++ b/configs/lists/phraselists/Makefile.am
@@ -9,7 +9,7 @@ MYSUBDIRS = chinesebig5 chinesegb2312 danish dutch french german italian japanes
 
 
 #install-data-local:
-#	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \\
+#	$(MKDIR_P) $(DESTDIR)$(E2DATADIR); \
 #		for l in $(WLISTS) ; do \
 #		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 #		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
@@ -38,7 +38,7 @@ install-data-local:
 	for lang in $(MYSUBDIRS); do \
 	for l in $(PHRASELISTS); do \
 	        if test -d $(srcdir)/$$lang/$$l ; then \
-	        $(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$lang/$$l; \\
+	        $(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$lang/$$l; \
 		for f in $(srcdir)/$$lang/$$l/weighted* $(srcdir)/$$lang/$$l/exception* $(srcdir)/$$lang/$$l/banned*; do \
 		   if test -f $$f ; then \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$lang/$$l"; \
@@ -50,7 +50,7 @@ install-data-local:
 	done
 	for compat in $(COMPAT_DIRS); do \
 	        if test -d $(srcdir)/../oldphraselists/$$compat ; then \
-	                $(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$compat; \\
+	                $(MKDIR_P) $(DESTDIR)$(E2DATADIR)/$$compat; \
 	                for f in $(srcdir)/../oldphraselists/$$compat/weighted* \
 	                         $(srcdir)/../oldphraselists/$$compat/exception* \
 	                         $(srcdir)/../oldphraselists/$$compat/banned*; do \
@@ -86,8 +86,8 @@ dist-hook:
 	    || mkdir $(distdir)/$$lang/$$phrase \
 	    || exit 1; \
 	    for f in $(srcdir)/$$lang/$$phrase/weighted* $(srcdir)/$$lang/$$phrase/banned* $(srcdir)/$$lang/$$phrase/exception*; do \
-	      if test -f $$f ; then \
-	        cp -p $$f $(distdir)/$$lang/$$phrase ;\
+              if test -f $$f ; then \
+                cp -p $$f $(distdir)/$$lang/$$phrase ; \
 	      fi; \
 	    done; \
 	  fi; \


### PR DESCRIPTION
## Summary
- replace doubled trailing backslashes in install and uninstall loops across the configuration Makefiles
- ensure each generated shell loop uses a single line-continuation backslash to avoid syntax errors during make install

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f16f530f8c832eb84b469a79c30a62