### PR TITLE
Add legacy sample lists required by FreeBSD packaging

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -18,7 +18,8 @@ SAMPLELISTS = domainsnobypass \
         urlnobypass \
         newbannedphraselist \
         newexceptionphraselist \
-        newweightedphraselist
+        newweightedphraselist \
+        filtergroupslist
 
 EXTRA_DIST = domainsnobypass.in \
              ipnobypass \

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -5,6 +5,7 @@ E2DATADIR = $(E2CONFDIR)/lists
 SUBDIRS = .
 
 SAMPLELISTS = authexceptioniplist \
+authexceptionsiteiplist \
 authexceptionsitelist \
 authexceptionurllist \
 bannedclientlist \

--- a/configs/lists/common/README
+++ b/configs/lists/common/README
@@ -28,6 +28,7 @@ exceptionclientlist
 # to allow for machines to update without user authentication
 #
 authexceptioniplist
+authexceptionsiteiplist
 authexceptionsitelist
 authexceptionurllist
 

--- a/configs/lists/common/authexceptionsiteiplist
+++ b/configs/lists/common/authexceptionsiteiplist
@@ -1,0 +1,12 @@
+#Access allowed prior to authentication
+# IP site addresses (deprecated name)
+#
+# This list mirrors authexceptioniplist and is retained for
+# compatibility with packaging expecting the historic filename.
+# Single IPs, ranges and subnets can be used,
+# e.g.
+# 192.168.0.1
+# 10.0.0.1-10.0.0.3
+# 10.0.0.0/24
+#
+# New deployments should use authexceptioniplist.

--- a/configs/lists/filtergroupslist
+++ b/configs/lists/filtergroupslist
@@ -1,0 +1,14 @@
+# Filter Groups List file for e2guardian
+#
+# This legacy location is retained for packaging compatibility.
+# The active copy installed for authentication plugins lives in
+# lists/authplugins/filtergroupslist.
+#
+# Format is <user>=<1-99> where 1-99 are the groups
+# Legacy format is also recognised: <user>=filter<1-99> where 1-99 are the groups
+#
+# Eg:
+# daniel=2
+#
+# This file is only of use if you have more than 1 filter group
+#

--- a/configs/lists/phraselists/danish/goodphrases/weighted_general
+++ b/configs/lists/phraselists/danish/goodphrases/weighted_general
@@ -1,0 +1,8 @@
+#listcategory: "GoodPhrases (Swedish)"
+
+#
+# Good phrases in Danish
+#
+<undervisning><-35> #education
+<oplysning><-15> #educating information
+

--- a/configs/lists/phraselists/dutch/goodphrases/weighted_general
+++ b/configs/lists/phraselists/dutch/goodphrases/weighted_general
@@ -1,0 +1,7 @@
+#listcategory: "GoodPhrases (Dutch)"
+
+#
+# Good phrases in Dutch
+#
+< kerk ><-60> #church
+

--- a/configs/lists/phraselists/malay/goodphrases/weighted_general
+++ b/configs/lists/phraselists/malay/goodphrases/weighted_general
@@ -1,0 +1,8 @@
+#listcategory: "GoodPhrases (Malay)"
+#
+# Created by Sazarul Izam <izam@oscc.org.my>
+# Sorted by words
+#
+
+<zina>,<islam><-30>
+<main><-10>

--- a/configs/lists/phraselists/polish/goodphrases/weighted_general
+++ b/configs/lists/phraselists/polish/goodphrases/weighted_general
@@ -1,0 +1,44 @@
+﻿#listcategory: "GoodPhrases (Polish)"
+
+<antykoncepcja><-30>
+<bezpłodność><-60>
+<biblia><-30>
+<biblistyka><-30>
+<ciąża><-40>
+<duchowość><-50>
+<edukacja><-30>
+<edukacja seksualna><-50>
+<farmacja><-30>
+<federacja><-30>
+<informacje>,<narkotyki><-20>
+<kościół><-50>
+<medycyna><-20>
+<medycyna>,<biologia><-50>
+<nowości><-50>
+<płodność><-80>
+<poradnik zdrowia><-80>
+<problemy seksualne><-30>
+<psychologia><-80>
+<rak piersi><-50>
+<rak><-10>
+<raport><-50>
+<rodzicielstwo><-80>
+<rodzina><-80>
+<rodzinie><-80>
+<rodzinny><-80>
+<seksuolog><-80>
+<telefon zaufania><-80>
+<terapia><-80>
+<towarzystwo><-30>
+<uzależnieni><-60>
+<uzależnienia><-50>
+<uzależnienie><-50>
+<uzależnienie od porno><-80>
+<uzależnienie od pornografii><-80>
+<wiki><-30>
+<wikipedia><-30>
+<wzpółuzależnienie><-80>
+<zdrowie><-10>
+<zdrowie>,<fizyczne><-30>
+<zdrowie>,<psychiczne><-50>
+<zdrowie>,<uroda><-50>

--- a/configs/lists/phraselists/portuguese/goodphrases/weighted_general
+++ b/configs/lists/phraselists/portuguese/goodphrases/weighted_general
@@ -1,0 +1,46 @@
+#listcategory: "GoodPhrases (Brazilian Portuguese)"
+
+#
+# Good phrases in Brazilian Portuguese
+#
+<doao><-20>
+<doacao><-20>
+<doaao><-20>
+<femea><-20>
+<fmea><-20>
+<vira-lata><-20>
+<filhote><-20>
+<amor><-20>
+<carinho><-20>
+<afeto><-20>
+<abandon><-30>
+<desaparecid><-30>
+<procura-se><-20>
+<vendo><-15>
+<deficiente><-20>
+<deficincia><-20>
+<deficiencia><-20>
+<adoo><-20>
+<adocao><-20>
+<adotar><-20>
+<tunning><-10>
+<tunado><-10>
+<noticia><-20>
+<notcia><-20>
+<software livre><-20>
+<tutorial><-20>
+<comunidade><-10>
+<artigo><-20>
+<foto>,<satelite><-20>
+<foto>,<telescopio><-20>
+<vestibular><-10>
+<graduao><-10>
+<graduacao><-10>
+<ps-graduao><-10>
+<pos-graduacao><-10>
+<pesquisa><-10>
+<cultura><-10>
+<biblioteca><-10>
+<museus><-10>
+<museolog><-30>
+

--- a/configs/lists/phraselists/swedish/goodphrases/weighted_general
+++ b/configs/lists/phraselists/swedish/goodphrases/weighted_general
@@ -1,0 +1,98 @@
+#listcategory: "GoodPhrases (Swedish)"
+#
+# Goodphrases in swedish
+# Contains news, medical,
+# goverment, education and more.
+# By Andreas Fors [srfiie@gmail.com]
+#
+<nyheter><-40>
+<aftonbladet><-100>
+<vrdcentral><-100>
+<expressen><-100>
+<test ><-5>
+< sport><-70>
+<bandy><-60>
+<hockey ><-60>
+< HVB ><-100>
+< vrd ><-100>
+< LSS ><-100>
+< LVU ><-100>
+< damp ><-50>
+< adhd ><-50>
+< redaktion ><-30>
+< posten ><-90>
+<skola ><-50>
+<verksamhet><-30>
+< bolag><-40>
+< bolaget><-30>
+<uppslags><-30>
+<resultat><-10>
+< webmail ><-50>
+< epost ><-5>
+< skatt ><-30>
+<dormsjskolan><-100>
+< tg ><-40>
+<svt><-50>
+<webtv><-20>
+< boka ><-20>
+< microsoft ><-40>
+< ekonomi><-50>
+< husdjur><-50>
+< utbildning><-40>
+< webbhotell ><-20>
+< arbetsgivare ><-40>
+< arbetsskande ><-40>
+< tabl ><-30>
+<tv-tabl><-50>
+< hlsa ><-50>
+<hlsa>,<sjukvrd><-60>
+<hlsa>,<sjukdom><-60>
+<hlsa>,<medecin><-60>
+< sjukvrd ><-20>
+<brst>,<nyheter><-20>
+< ansiktsmask ><-10>
+<ledare><-30>
+< jobb><-40>
+< ekonominyheter ><-100>
+< diplomat ><-40>
+<semester ><-30>
+< landslaget >,<sport><-50>
+<television><-20>
+<resa ><-30>
+< avsljar >,< nyhet><-50>
+<annons><-20>
+<brst>,<cancer><-60>
+<felskning><-40>
+< barn >,<skola><-50>
+< barn >,<utbildning><-50>
+< behandling >,<barn><-50>
+<katt><-10>
+<bokning><-20>
+<flyg><-35>
+<prst><-30>
+< prst >,< kyrka><-50>
+<dikter><-40>
+<polis >,< myndighet ><-50>
+<polis >,< verksamhet ><-50>
+<polis >,< spaning ><-50>
+< kyrka ><-35>
+< domstol ><-40>
+< matematik ><-40>
+<skola>,<lxa><-50>
+< studier ><-40>
+< advokat ><-40>
+<byr ><-25>
+<tumr ><-40>
+< sex >,< rdgivning ><-50>
+< kykling>,< brst ><-40>
+< kalkon >,< brst ><-40>
+< matlagning ><-40>
+< mat >,<recept ><-50>
+< mat >,< soppor><-50>
+<dator>,<hrdvara><-50>
+<dator>,<mjukvara><-50>
+< ekonomi >,< nyheter ><-50>
+< arbetsls ><-20>
+< hst>,<annonser ><-50>
+<social><-40>
+< kanal5 ><-60>


### PR DESCRIPTION
## Summary
- add authexceptionsiteiplist and filtergroupslist legacy samples and ensure they install with other common lists
- restore weighted_general good phrase samples for languages expected by downstream packaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f17d4e0d40832e89297bc23f11d3d9