### PR TITLE
Ensure autogen.sh creates autom4te compatibility aliases

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -73,16 +73,18 @@ ensure_autom4te_wrapper() {
 
         local need_wrapper=0
         for version in $versions; do
-                if command -v "autom4te-$version" >/dev/null 2>&1; then
-                        continue
-                fi
-                need_wrapper=1
-                local wrapper="$helper_dir/autom4te-$version"
-                cat <<EOF_WRAPPER >"$wrapper"
+                for wrapper_name in "autom4te-$version" "autom4te$version"; do
+                        if command -v "$wrapper_name" >/dev/null 2>&1; then
+                                continue
+                        fi
+                        need_wrapper=1
+                        local wrapper="$helper_dir/$wrapper_name"
+                        cat <<EOF_WRAPPER >"$wrapper"
 #!/bin/sh
 exec "$fallback_path" "\$@"
 EOF_WRAPPER
-                chmod +x "$wrapper"
+                        chmod +x "$wrapper"
+                done
         done
 
         if [ "$need_wrapper" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- update autogen.sh to generate both hyphenated and non-hyphenated autom4te version wrappers
- ensure FreeBSD ports infrastructure finds the expected autom4te-2.71 helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1929744f4832e94887a0907ed95dd