### PR TITLE
Fix __CONFFILE definition to expand prefix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -655,7 +655,7 @@ AC_FINALIZE_VAR(E2CONFFILE,"${e2sysconfdir}/${PACKAGE_NAME}.conf")
 AC_SUBST(E2CONFFILE)
 #AC_DEFINE_UNQUOTED(__CONFDIR,"${e2sysconfdir}","")
 AC_DEFINE_UNQUOTED([__DATADIR],["${E2DATADIR}"],["Data directory path"])
-AC_DEFINE_UNQUOTED(__CONFFILE,"${e2sysconfdir}/${PACKAGE_NAME}.conf","Configure file path")
+AC_DEFINE_UNQUOTED(__CONFFILE,"${E2CONFFILE}","Configure file path")
 
 AC_CONFIG_FILES([Makefile
 data/Makefile


### PR DESCRIPTION
## Summary
- ensure the __CONFFILE definition in configure.ac uses the fully expanded E2CONFFILE value so that ${prefix} is resolved at configure time

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f25e3f89c4832e87e1b06a32654ddd