### PR TITLE
Add fallback ipgroups path for IP auth plugin

### DIFF
--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -178,6 +178,17 @@ int ipinstance::init(void *args)
     }
 
     if (ipgroups_path.empty()) {
+        std::string default_ipgroups = std::string(__CONFDIR) + "/lists/authplugins/ipgroups";
+        if (access(default_ipgroups.c_str(), R_OK) == 0) {
+            ipgroups_path = default_ipgroups;
+            if (!is_daemonised)
+                std::cerr << thread_id << "No ipgroups list defined for IP auth plugin, falling back to "
+                          << ipgroups_path << std::endl;
+            syslog(LOG_INFO, "No ipgroups list defined for IP auth plugin, falling back to %s", ipgroups_path.c_str());
+        }
+    }
+
+    if (ipgroups_path.empty()) {
         if (!is_daemonised)
             std::cerr << thread_id << "No ipgroups file defined for IP auth plugin" << std::endl;
         syslog(LOG_ERR, "No ipgroups file defined for IP auth plugin");


### PR DESCRIPTION
## Summary
- add a fallback ipgroups list path for the IP auth plugin when no mapping file is configured
- log an informational message when the fallback list is used to aid troubleshooting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2e6d95010832e91fe1db18e5a7826