### PR TITLE
Ensure authplugin lists are installed with configs

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -12,14 +12,31 @@ endif
 FLISTS = e2guardian.conf e2guardianf1.conf examplef1.story common.story \
         site.story preauth.story
 
+AUTHPLUGIN_LISTS = lists/authplugins/ipgroups \
+        lists/authplugins/portgroups \
+        lists/authplugins/filtergroupslist
+
 EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in
 
 
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR); \
 	for l in $(FLISTS) ; do \
-		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
-		$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
+	echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
+	$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
+	done
+
+install-data-hook:
+	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR)/lists/authplugins; \
+	for l in $(AUTHPLUGIN_LISTS) ; do \
+	base=`basename $$l`; \
+	src="$(srcdir)/$$l"; \
+	echo "$(INSTALL_DATA) $$src $(DESTDIR)$(E2CONFDIR)/lists/authplugins/$$base.sample"; \
+	$(INSTALL_DATA) $$src $(DESTDIR)$(E2CONFDIR)/lists/authplugins/$$base.sample; \
+	if test ! -f $(DESTDIR)$(E2CONFDIR)/lists/authplugins/$$base ; then \
+	echo "$(INSTALL_DATA) $$src $(DESTDIR)$(E2CONFDIR)/lists/authplugins/$$base"; \
+	$(INSTALL_DATA) $$src $(DESTDIR)$(E2CONFDIR)/lists/authplugins/$$base; \
+	fi; \
 	done
 
 uninstall-local:


### PR DESCRIPTION
## Summary
- ensure the config installation step always creates the lists/authplugins directory
- install the authplugin map files (ipmap, portmap, filtergroupslist) when configs are installed so IP auth works out of the box

## Testing
- make -C configs DESTDIR=/tmp/e2g-test install-data

------
https://chatgpt.com/codex/tasks/task_e_68f304a4550c832e815fbd543915563c