### PR TITLE
Add ident story entry to preauth storyboard

### DIFF
--- a/configs/preauth.story
+++ b/configs/preauth.story
@@ -50,6 +50,10 @@ if(userin,defaultusermap) return setgroup
 function(auth_proxy_ident)
 if(userin,defaultusermap) return setgroup
 
+# ident auth plugin (native IDENT client lookup)
+function(auth_ident)
+if(userin,defaultusermap) return setgroup
+
 function(auth_proxy_ntlm)
 if(userin,defaultusermap) return setgroup
 


### PR DESCRIPTION
## Summary
- add an explicit `auth_ident` entry in `preauth.story` so the ident auth plugin can resolve a storyboard function
- keep the existing proxy ident entry while documenting the new function for clarity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f307519e7c832eacc280da40396d0c