### PR TITLE
Fix CIDR netmask parsing for IP-based lookups

### DIFF
--- a/src/IPList.cpp
+++ b/src/IPList.cpp
@@ -157,21 +157,23 @@ bool IPList::ifsreadIPMelangeList(std::ifstream *input, bool checkendstring, con
             }
         } else if (matchCIDR.match(line.toCharArray(),Rre)) {
             struct in_addr address;
-            struct in_addr addressmask;
             String subnet(line.before("/"));
             String cidr(line.after("/"));
             int m = cidr.toInteger();
-            int host_part = 32 - m;
-            if (host_part > -1) {
-                String mask = (0xFFFFFFFF << host_part);
-                if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                    ipl_subnetstruct s;
-                    uint32_t addr = ntohl(address.s_addr);
-                    s.mask = ntohl(addressmask.s_addr);
-                    // pre-mask the address for quick comparison
-                    s.maskedaddr = addr & s.mask;
-                    ipsubnetlist.push_back(s);
-                }
+            if (m < 0 || m > 32) {
+                if (!is_daemonised)
+                    std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << std::endl;
+                syslog(LOG_ERR, "Invalid CIDR prefix; entry %s", line.toCharArray());
+                continue;
+            }
+            if (inet_aton(subnet.toCharArray(), &address)) {
+                uint32_t addr = ntohl(address.s_addr);
+                uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+                ipl_subnetstruct s;
+                s.mask = mask;
+                // pre-mask the address for quick comparison
+                s.maskedaddr = addr & s.mask;
+                ipsubnetlist.push_back(s);
             }
         } else if (matchRange.match(line.toCharArray(),Rre)) {
             struct in_addr addressstart;

--- a/src/ListContainer.cpp
+++ b/src/ListContainer.cpp
@@ -1648,21 +1648,21 @@ void ListContainer::addToIPList(String &line) {
         }
     } else if (matchCIDR.match(line.toCharArray(), Rre)) {
         struct in_addr address;
-        struct in_addr addressmask;
         String subnet(line.before("/"));
         String cidr(line.after("/"));
         int m = cidr.toInteger();
-        int host_part = 32 - m;
-        if (host_part > -1) {
-            String mask = (0xFFFFFFFF << host_part);
-            if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                ipl_subnetstruct s;
-                uint32_t addr = ntohl(address.s_addr);
-                s.mask = ntohl(addressmask.s_addr);
-                // pre-mask the address for quick comparison
-                s.maskedaddr = addr & s.mask;
-                ipsubnetlist.push_back(s);
-            }
+        if (m < 0 || m > 32) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << std::endl;
+            syslog(LOG_ERR, "Invalid CIDR prefix; entry %s", line.toCharArray());
+        } else if (inet_aton(subnet.toCharArray(), &address)) {
+            ipl_subnetstruct s;
+            uint32_t addr = ntohl(address.s_addr);
+            uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+            s.mask = mask;
+            // pre-mask the address for quick comparison
+            s.maskedaddr = addr & s.mask;
+            ipsubnetlist.push_back(s);
         }
     } else if (matchRange.match(line.toCharArray(), Rre)) {
         struct in_addr addressstart;
@@ -1809,22 +1809,22 @@ void ListContainer::addToIPMap(String &line) {
     } else if (matchCIDR.match(key.toCharArray(), Rre)) {
 //        std::cerr << "Is CIDR " << key << std::endl;
         struct in_addr address;
-        struct in_addr addressmask;
         String subnet(key.before("/"));
         String cidr(key.after("/"));
         int m = cidr.toInteger();
-        int host_part = 32 - m;
-        if (host_part > -1) {
-            String mask = (0xFFFFFFFF << host_part);
-            if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                subnetstruct s;
-                uint32_t addr = ntohl(address.s_addr);
-                s.mask = ntohl(addressmask.s_addr);
-                // pre-mask the address for quick comparison
-                s.maskedaddr = addr & s.mask;
-                s.group = value;
-                ipmapsubnetlist.push_back(s);
-            }
+        if (m < 0 || m > 32) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << " in " << sourcefile << std::endl;
+            syslog(LOG_ERR, "Invalid CIDR prefix; entry %s in %s", line.toCharArray(), sourcefile.c_str());
+        } else if (inet_aton(subnet.toCharArray(), &address)) {
+            subnetstruct s;
+            uint32_t addr = ntohl(address.s_addr);
+            uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+            s.mask = mask;
+            // pre-mask the address for quick comparison
+            s.maskedaddr = addr & s.mask;
+            s.group = value;
+            ipmapsubnetlist.push_back(s);
         }
     } else if (matchRange.match(key.toCharArray(), Rre)) {
 //        std::cerr << "Is IP range " << key << std::endl;

--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -495,8 +495,14 @@ int ipinstance::parseFilterGroup(const String &value, const char *filename, cons
         }
     }
 
-    String numeric = digits.length() > 0 ? digits : normalised;
+    bool has_digits = digits.length() > 0;
+    String numeric = has_digits ? digits : normalised;
     int group = numeric.toInteger();
+    if (has_digits && group == 0) {
+        if (o.filter_groups > 0)
+            return 0;
+        group = -1;
+    }
     if ((group < 1) || (group > o.filter_groups)) {
         if (!is_daemonised)
             std::cerr << thread_id << "Filter group out of range; entry " << line << " in " << filename << std::endl;
@@ -590,22 +596,25 @@ int ipinstance::readIPMelangeList(const char *filename)
             }
         } else if (matchCIDR.match(key.toCharArray(),Rre)) {
             struct in_addr address;
-            struct in_addr addressmask;
             String subnet(key.before("/"));
             String cidr(key.after("/"));
             int m = cidr.toInteger();
-            int host_part = 32 - m;
-            if (host_part > -1) {
-                String mask = (0xFFFFFFFF << host_part);
-                if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                    ip_subnet_entry s;
-                    uint32_t addr = ntohl(address.s_addr);
-                    s.mask = ntohl(addressmask.s_addr);
-                    // pre-mask the address for quick comparison
-                    s.maskedaddr = addr & s.mask;
-                    s.group = group;
-                    ipsubnetlist.push_back(s);
-                }
+            if (m < 0 || m > 32) {
+                if (!is_daemonised)
+                    std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << " in " << filename << std::endl;
+                syslog(LOG_ERR, "Invalid CIDR prefix; entry %s in %s", line.toCharArray(), filename);
+                warn = true;
+                continue;
+            }
+            if (inet_aton(subnet.toCharArray(), &address)) {
+                uint32_t addr = ntohl(address.s_addr);
+                uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+                ip_subnet_entry s;
+                s.mask = mask;
+                // pre-mask the address for quick comparison
+                s.maskedaddr = addr & s.mask;
+                s.group = group;
+                ipsubnetlist.push_back(s);
             }
         } else if (matchRange.match(key.toCharArray(),Rre)) {
             struct in_addr addressstart;


### PR DESCRIPTION
## Summary
- compute CIDR masks with unsigned arithmetic in the IP auth plugin to avoid undefined shifts and honour prefix length validation
- apply the same CIDR handling to the shared IP list and ipmap loaders so subnet matching works consistently
- permit explicit filter group 0 entries when parsing ipgroups and log invalid CIDR prefixes for easier troubleshooting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f3cd5056f0832e8c6d2ab5ef693715