### PR TITLE
Handle special IP list entries without assigning groups

### DIFF
--- a/src/IPList.cpp
+++ b/src/IPList.cpp
@@ -157,21 +157,23 @@ bool IPList::ifsreadIPMelangeList(std::ifstream *input, bool checkendstring, con
             }
         } else if (matchCIDR.match(line.toCharArray(),Rre)) {
             struct in_addr address;
-            struct in_addr addressmask;
             String subnet(line.before("/"));
             String cidr(line.after("/"));
             int m = cidr.toInteger();
-            int host_part = 32 - m;
-            if (host_part > -1) {
-                String mask = (0xFFFFFFFF << host_part);
-                if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                    ipl_subnetstruct s;
-                    uint32_t addr = ntohl(address.s_addr);
-                    s.mask = ntohl(addressmask.s_addr);
-                    // pre-mask the address for quick comparison
-                    s.maskedaddr = addr & s.mask;
-                    ipsubnetlist.push_back(s);
-                }
+            if (m < 0 || m > 32) {
+                if (!is_daemonised)
+                    std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << std::endl;
+                syslog(LOG_ERR, "Invalid CIDR prefix; entry %s", line.toCharArray());
+                continue;
+            }
+            if (inet_aton(subnet.toCharArray(), &address)) {
+                uint32_t addr = ntohl(address.s_addr);
+                uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+                ipl_subnetstruct s;
+                s.mask = mask;
+                // pre-mask the address for quick comparison
+                s.maskedaddr = addr & s.mask;
+                ipsubnetlist.push_back(s);
             }
         } else if (matchRange.match(line.toCharArray(),Rre)) {
             struct in_addr addressstart;

--- a/src/ListContainer.cpp
+++ b/src/ListContainer.cpp
@@ -141,6 +141,33 @@ bool ensureListFileExists(const char *filename) {
     return true;
 }
 
+enum class SpecialIpGroup
+{
+    None,
+    Exception,
+    Banned
+};
+
+SpecialIpGroup classify_special_group(String token)
+{
+    token.toLower();
+    token.removeWhiteSpace();
+    token.removePunctuation();
+    token.removeChar('_');
+    token.removeChar('-');
+
+    if (token.length() == 0)
+        return SpecialIpGroup::None;
+
+    if ((token == "exceptioniplist") || (token == "exceptionlist") || (token == "exceptionip"))
+        return SpecialIpGroup::Exception;
+
+    if ((token == "bannediplist") || (token == "bannedlist") || (token == "bannedip"))
+        return SpecialIpGroup::Banned;
+
+    return SpecialIpGroup::None;
+}
+
 } // namespace
 
 
@@ -1648,21 +1675,21 @@ void ListContainer::addToIPList(String &line) {
         }
     } else if (matchCIDR.match(line.toCharArray(), Rre)) {
         struct in_addr address;
-        struct in_addr addressmask;
         String subnet(line.before("/"));
         String cidr(line.after("/"));
         int m = cidr.toInteger();
-        int host_part = 32 - m;
-        if (host_part > -1) {
-            String mask = (0xFFFFFFFF << host_part);
-            if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                ipl_subnetstruct s;
-                uint32_t addr = ntohl(address.s_addr);
-                s.mask = ntohl(addressmask.s_addr);
-                // pre-mask the address for quick comparison
-                s.maskedaddr = addr & s.mask;
-                ipsubnetlist.push_back(s);
-            }
+        if (m < 0 || m > 32) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << std::endl;
+            syslog(LOG_ERR, "Invalid CIDR prefix; entry %s", line.toCharArray());
+        } else if (inet_aton(subnet.toCharArray(), &address)) {
+            ipl_subnetstruct s;
+            uint32_t addr = ntohl(address.s_addr);
+            uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+            s.mask = mask;
+            // pre-mask the address for quick comparison
+            s.maskedaddr = addr & s.mask;
+            ipsubnetlist.push_back(s);
         }
     } else if (matchRange.match(line.toCharArray(), Rre)) {
         struct in_addr addressstart;
@@ -1691,30 +1718,40 @@ void ListContainer::addToDataMap(String &line) {
     if (line.contains("=")) {
         key = line.before("=");
         key.removeWhiteSpace();
-        value = line.after("=");
+        String group_value(line.after("="));
+        SpecialIpGroup special = classify_special_group(group_value);
+        bool is_special = (special != SpecialIpGroup::None);
+        value = group_value;
         value.removeWhiteSpace();
-        String normalised(value);
-        normalised.toLower();
-        if (normalised.startsWith("filter"))
-            normalised = normalised.after("filter");
-        if (normalised.startsWith("group"))
-            normalised = normalised.after("group");
-        normalised.removeWhiteSpace();
-        String digits;
-        const char *ptr = normalised.toCharArray();
-        for (size_t i = 0; ptr[i] != '\0'; ++i) {
-            if (isdigit(static_cast<unsigned char>(ptr[i]))) {
-                digits += ptr[i];
-            } else if (digits.length() > 0) {
-                break;
+        if (is_special) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Marking special IP list entry " << line << " in " << sourcefile << std::endl;
+            syslog(LOG_INFO, "Marking special IP list entry %s in %s", line.toCharArray(), sourcefile.c_str());
+            value = "";
+        } else {
+            String normalised(value);
+            normalised.toLower();
+            if (normalised.startsWith("filter"))
+                normalised = normalised.after("filter");
+            if (normalised.startsWith("group"))
+                normalised = normalised.after("group");
+            normalised.removeWhiteSpace();
+            String digits;
+            const char *ptr = normalised.toCharArray();
+            for (size_t i = 0; ptr[i] != '\0'; ++i) {
+                if (isdigit(static_cast<unsigned char>(ptr[i]))) {
+                    digits += ptr[i];
+                } else if (digits.length() > 0) {
+                    break;
+                }
             }
+            if (digits.length() > 0)
+                normalised = digits;
+            value = normalised;
+            value.removeWhiteSpace();
+            if (value.startsWith("filter"))
+                value = value.after("filter");
         }
-        if (digits.length() > 0)
-            normalised = digits;
-        value = normalised;
-        value.removeWhiteSpace();
-        if (value.startsWith("filter"))
-            value = value.after("filter");
     } else {
         if (!is_daemonised)
             std::cerr << thread_id << "No filter group given; entry " << line << " in " << sourcefile << std::endl;
@@ -1738,30 +1775,49 @@ void ListContainer::addToIPMap(String &line) {
     if (line.contains("=")) {
         key = line.before("=");
         key.removeWhiteSpace();
-        value = line.after("=");
+        String group_value(line.after("="));
+        SpecialIpGroup special = classify_special_group(group_value);
+        bool is_special = (special != SpecialIpGroup::None);
+        value = group_value;
         value.removeWhiteSpace();
-        String normalised(value);
-        normalised.toLower();
-        if (normalised.startsWith("filter"))
-            normalised = normalised.after("filter");
-        if (normalised.startsWith("group"))
-            normalised = normalised.after("group");
-        normalised.removeWhiteSpace();
-        String digits;
-        const char *ptr = normalised.toCharArray();
-        for (size_t i = 0; ptr[i] != '\0'; ++i) {
-            if (isdigit(static_cast<unsigned char>(ptr[i]))) {
-                digits += ptr[i];
-            } else if (digits.length() > 0) {
-                break;
+        if (is_special) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Marking special IP list entry " << line << " in " << sourcefile << std::endl;
+            syslog(LOG_INFO, "Marking special IP list entry %s in %s", line.toCharArray(), sourcefile.c_str());
+            value = "";
+        } else {
+            String normalised(value);
+            normalised.toLower();
+            if (normalised.startsWith("filter"))
+                normalised = normalised.after("filter");
+            if (normalised.startsWith("group"))
+                normalised = normalised.after("group");
+            normalised.removeWhiteSpace();
+            String digits;
+            const char *ptr = normalised.toCharArray();
+            for (size_t i = 0; ptr[i] != '\0'; ++i) {
+                if (isdigit(static_cast<unsigned char>(ptr[i]))) {
+                    digits += ptr[i];
+                } else if (digits.length() > 0) {
+                    break;
+                }
             }
+            if (digits.length() > 0)
+                normalised = digits;
+            value = normalised;
+            value.removeWhiteSpace();
         }
-        if (digits.length() > 0)
-            normalised = digits;
-        value = normalised;
-        value.removeWhiteSpace();
         if (value.startsWith("filter"))
             value = value.after("filter");
+        if (!is_special) {
+            if ((value.toInteger() < 1) || (value.toInteger() > o.filter_groups)) {
+                if (!is_daemonised)
+                    std::cerr << thread_id << "Filter group out of range; entry " << line << " in " << sourcefile << std::endl;
+                syslog(LOG_ERR, "Filter group out of range; entry %s in %s", line.toCharArray(), sourcefile.c_str());
+                //warn = true;
+                return;
+            }
+        }
     } else {
         if (!is_daemonised)
             std::cerr << thread_id << "No filter group given; entry " << line << " in " << sourcefile << std::endl;
@@ -1773,13 +1829,7 @@ void ListContainer::addToIPMap(String &line) {
     std::cerr << thread_id << "key: " << key << std::endl;
     std::cerr << thread_id << "value: " << value.toInteger() << std::endl;
 #endif
-    if ((value.toInteger() < 1) || (value.toInteger() > o.filter_groups)) {
-        if (!is_daemonised)
-            std::cerr << thread_id << "Filter group out of range; entry " << line << " in " << sourcefile << std::endl;
-        syslog(LOG_ERR, "Filter group out of range; entry %s in %s", line.toCharArray(), sourcefile.c_str());
-        //warn = true;
-        return;
-    }
+    // range check already performed for non-special entries above
 
     // store the IP address (numerically, not as a string) and filter group in either the IP list, subnet list or range list
     if (matchIP.match(key.toCharArray(), Rre)) {
@@ -1809,22 +1859,22 @@ void ListContainer::addToIPMap(String &line) {
     } else if (matchCIDR.match(key.toCharArray(), Rre)) {
 //        std::cerr << "Is CIDR " << key << std::endl;
         struct in_addr address;
-        struct in_addr addressmask;
         String subnet(key.before("/"));
         String cidr(key.after("/"));
         int m = cidr.toInteger();
-        int host_part = 32 - m;
-        if (host_part > -1) {
-            String mask = (0xFFFFFFFF << host_part);
-            if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                subnetstruct s;
-                uint32_t addr = ntohl(address.s_addr);
-                s.mask = ntohl(addressmask.s_addr);
-                // pre-mask the address for quick comparison
-                s.maskedaddr = addr & s.mask;
-                s.group = value;
-                ipmapsubnetlist.push_back(s);
-            }
+        if (m < 0 || m > 32) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << " in " << sourcefile << std::endl;
+            syslog(LOG_ERR, "Invalid CIDR prefix; entry %s in %s", line.toCharArray(), sourcefile.c_str());
+        } else if (inet_aton(subnet.toCharArray(), &address)) {
+            subnetstruct s;
+            uint32_t addr = ntohl(address.s_addr);
+            uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+            s.mask = mask;
+            // pre-mask the address for quick comparison
+            s.maskedaddr = addr & s.mask;
+            s.group = value;
+            ipmapsubnetlist.push_back(s);
         }
     } else if (matchRange.match(key.toCharArray(), Rre)) {
 //        std::cerr << "Is IP range " << key << std::endl;

--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -109,13 +109,75 @@ class ipinstance : public AuthPlugin
     int inList(const uint32_t &ip);
     int inSubnet(const uint32_t &ip);
     int inRange(const uint32_t &ip);
-    int parseFilterGroup(const String &value, const char *filename, const String &line, bool &warn);
+    int parseFilterGroup(const String &value, const char *filename, const String &line, bool &warn, SpecialIpGroup &special_out);
 };
 
 // IMPLEMENTATION
 
 namespace
 {
+enum class SpecialIpGroup
+{
+    None,
+    Exception,
+    Banned
+};
+
+constexpr int kHiddenExceptionGroup = -2;
+constexpr int kHiddenBannedGroup = -3;
+
+SpecialIpGroup classify_special_group(String token)
+{
+    token.toLower();
+    token.removeWhiteSpace();
+    token.removePunctuation();
+    token.removeChar('_');
+    token.removeChar('-');
+
+    if (token.length() == 0)
+        return SpecialIpGroup::None;
+
+    if ((token == "exceptioniplist") || (token == "exceptionlist") || (token == "exceptionip"))
+        return SpecialIpGroup::Exception;
+
+    if ((token == "bannediplist") || (token == "bannedlist") || (token == "bannedip"))
+        return SpecialIpGroup::Banned;
+
+    return SpecialIpGroup::None;
+}
+
+SpecialIpGroup decode_hidden_group(int group)
+{
+    if (group == kHiddenExceptionGroup)
+        return SpecialIpGroup::Exception;
+    if (group == kHiddenBannedGroup)
+        return SpecialIpGroup::Banned;
+    return SpecialIpGroup::None;
+}
+
+bool apply_hidden_group(SpecialIpGroup special, const std::string &user, NaughtyFilter &cm)
+{
+    if (special == SpecialIpGroup::None)
+        return false;
+
+    if (cm.authrec != nullptr) {
+        cm.authrec->group_source = "ip";
+        cm.authrec->filter_group = -1;
+        cm.authrec->is_authed = true;
+        if (cm.authrec->user_name.length() == 0)
+            cm.authrec->user_name = user;
+    }
+
+    if (special == SpecialIpGroup::Exception) {
+        cm.isexception = true;
+        cm.isException = true;
+    } else if (special == SpecialIpGroup::Banned) {
+        cm.isBlocked = true;
+    }
+
+    return true;
+}
+
 int ensure_directories(const std::string &path)
 {
     if (path.empty())
@@ -372,6 +434,11 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
     int fg;
     // check straight IPs, subnets, and ranges
     fg = inList(addr);
+    SpecialIpGroup special = decode_hidden_group(fg);
+    if (apply_hidden_group(special, user, cm)) {
+        rfg = cm.filtergroup;
+        return E2AUTH_NOGROUP;
+    }
     if (fg >= 0) {
         rfg = fg;
         cm.filtergroup = rfg;
@@ -387,6 +454,11 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
         return E2AUTH_OK;
     }
     fg = inSubnet(addr);
+    special = decode_hidden_group(fg);
+    if (apply_hidden_group(special, user, cm)) {
+        rfg = cm.filtergroup;
+        return E2AUTH_NOGROUP;
+    }
     if (fg >= 0) {
         rfg = fg;
         cm.filtergroup = rfg;
@@ -402,6 +474,11 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
         return E2AUTH_OK;
     }
     fg = inRange(addr);
+    special = decode_hidden_group(fg);
+    if (apply_hidden_group(special, user, cm)) {
+        rfg = cm.filtergroup;
+        return E2AUTH_NOGROUP;
+    }
     if (fg >= 0) {
         rfg = fg;
         cm.filtergroup = rfg;
@@ -474,8 +551,14 @@ int ipinstance::inRange(const uint32_t &ip)
     return -1;
 }
 
-int ipinstance::parseFilterGroup(const String &value, const char *filename, const String &line, bool &warn)
+int ipinstance::parseFilterGroup(const String &value, const char *filename, const String &line, bool &warn, SpecialIpGroup &special)
 {
+    special = classify_special_group(value);
+    if (special == SpecialIpGroup::Exception)
+        return kHiddenExceptionGroup;
+    if (special == SpecialIpGroup::Banned)
+        return kHiddenBannedGroup;
+
     String normalised(value);
     normalised.toLower();
     normalised.removeWhiteSpace();
@@ -495,8 +578,14 @@ int ipinstance::parseFilterGroup(const String &value, const char *filename, cons
         }
     }
 
-    String numeric = digits.length() > 0 ? digits : normalised;
+    bool has_digits = digits.length() > 0;
+    String numeric = has_digits ? digits : normalised;
     int group = numeric.toInteger();
+    if (has_digits && group == 0) {
+        if (o.filter_groups > 0)
+            return 0;
+        group = -1;
+    }
     if ((group < 1) || (group > o.filter_groups)) {
         if (!is_daemonised)
             std::cerr << thread_id << "Filter group out of range; entry " << line << " in " << filename << std::endl;
@@ -565,9 +654,15 @@ int ipinstance::readIPMelangeList(const char *filename)
             warn = true;
             continue;
         }
-        int group = parseFilterGroup(value, filename, line, warn);
-        if (group < 0)
+        SpecialIpGroup special = SpecialIpGroup::None;
+        int group = parseFilterGroup(value, filename, line, warn, special);
+        if ((group < 0) && (special == SpecialIpGroup::None))
             continue;
+        if (special != SpecialIpGroup::None) {
+            if (!is_daemonised)
+                std::cerr << thread_id << "Matched special IP list entry " << line << " in " << filename << std::endl;
+            syslog(LOG_INFO, "Matched special IP list entry %s in %s", line.toCharArray(), filename);
+        }
         // store the IP address (numerically, not as a string) and filter group in either the IP list, subnet list or range list
         if (matchIP.match(key.toCharArray(),Rre)) {
             struct in_addr address;
@@ -590,22 +685,25 @@ int ipinstance::readIPMelangeList(const char *filename)
             }
         } else if (matchCIDR.match(key.toCharArray(),Rre)) {
             struct in_addr address;
-            struct in_addr addressmask;
             String subnet(key.before("/"));
             String cidr(key.after("/"));
             int m = cidr.toInteger();
-            int host_part = 32 - m;
-            if (host_part > -1) {
-                String mask = (0xFFFFFFFF << host_part);
-                if (inet_aton(subnet.toCharArray(), &address) && inet_aton(mask.toCharArray(), &addressmask)) {
-                    ip_subnet_entry s;
-                    uint32_t addr = ntohl(address.s_addr);
-                    s.mask = ntohl(addressmask.s_addr);
-                    // pre-mask the address for quick comparison
-                    s.maskedaddr = addr & s.mask;
-                    s.group = group;
-                    ipsubnetlist.push_back(s);
-                }
+            if (m < 0 || m > 32) {
+                if (!is_daemonised)
+                    std::cerr << thread_id << "Invalid CIDR prefix; entry " << line << " in " << filename << std::endl;
+                syslog(LOG_ERR, "Invalid CIDR prefix; entry %s in %s", line.toCharArray(), filename);
+                warn = true;
+                continue;
+            }
+            if (inet_aton(subnet.toCharArray(), &address)) {
+                uint32_t addr = ntohl(address.s_addr);
+                uint32_t mask = (m == 0) ? 0 : (0xFFFFFFFFu << (32 - m));
+                ip_subnet_entry s;
+                s.mask = mask;
+                // pre-mask the address for quick comparison
+                s.maskedaddr = addr & s.mask;
+                s.group = group;
+                ipsubnetlist.push_back(s);
             }
         } else if (matchRange.match(key.toCharArray(),Rre)) {
             struct in_addr addressstart;


### PR DESCRIPTION
## Summary
- preserve Exception and Banned IP list entries when parsing ipgroups and detect them during group resolution so the IP auth plugin returns E2AUTH_NOGROUP while flagging exceptions instead of falling back to the first filter group
- keep the special entries in auxiliary IP maps but clear their numeric group so reporting tools do not associate them with any filter group

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f3cd5056f0832e8c6d2ab5ef693715