### PR TITLE
Preserve default filter group for exception IP matches

### DIFF
--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -441,7 +441,7 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
     fg = inList(addr);
     SpecialIpGroup special = decode_hidden_group(fg);
     if (apply_hidden_group(special, user, cm)) {
-        rfg = cm.filtergroup;
+        cm.filtergroup = rfg;
         return E2AUTH_NOGROUP;
     }
     if (fg >= 0) {
@@ -461,7 +461,7 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
     fg = inSubnet(addr);
     special = decode_hidden_group(fg);
     if (apply_hidden_group(special, user, cm)) {
-        rfg = cm.filtergroup;
+        cm.filtergroup = rfg;
         return E2AUTH_NOGROUP;
     }
     if (fg >= 0) {
@@ -481,7 +481,7 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
     fg = inRange(addr);
     special = decode_hidden_group(fg);
     if (apply_hidden_group(special, user, cm)) {
-        rfg = cm.filtergroup;
+        cm.filtergroup = rfg;
         return E2AUTH_NOGROUP;
     }
     if (fg >= 0) {


### PR DESCRIPTION
## Summary
- keep the caller-provided filter group when an IP falls into the exception/banned hidden groups
- ensure the NaughtyFilter record continues to reflect that default filter group

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3e69bb4d0832ebf0c2f2b4a990edc