### PR TITLE
Improve username handling for proxy auth plugins

### DIFF
--- a/src/Auth.cpp
+++ b/src/Auth.cpp
@@ -16,6 +16,10 @@
 
 #include <iostream>
 #include <syslog.h>
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <arpa/inet.h>
 
 // GLOBALS
 
@@ -38,6 +42,79 @@ extern authcreate_t dnsauthcreate;
 #ifdef ENABLE_NTLM
 extern authcreate_t ntlmcreate;
 #endif
+
+namespace
+{
+std::string trim_copy(const std::string &value)
+{
+    auto begin = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) { return std::isspace(ch); });
+    auto end = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) { return std::isspace(ch); }).base();
+    if (begin >= end)
+        return std::string();
+    return std::string(begin, end);
+}
+
+bool is_likely_ip(const std::string &token)
+{
+    if (token.empty())
+        return false;
+
+    struct in_addr v4;
+    if (inet_pton(AF_INET, token.c_str(), &v4) == 1)
+        return true;
+
+#ifdef AF_INET6
+    struct in6_addr v6;
+    if (inet_pton(AF_INET6, token.c_str(), &v6) == 1)
+        return true;
+#endif
+
+    return false;
+}
+}
+
+std::string normalise_auth_username(const std::string &raw)
+{
+    std::string result = trim_copy(raw);
+    if (result.empty())
+        return result;
+
+    size_t slash_pos = result.find_last_of("\\/");
+    if (slash_pos != std::string::npos && slash_pos + 1 < result.size())
+        result = result.substr(slash_pos + 1);
+
+    size_t at_pos = result.find('@');
+    if (at_pos != std::string::npos)
+        result = result.substr(0, at_pos);
+
+    // Remove surrounding quotes if present.
+    if (result.size() > 1 && ((result.front() == '"' && result.back() == '"') || (result.front() == '\'' && result.back() == '\'')))
+        result = result.substr(1, result.size() - 2);
+
+    return trim_copy(result);
+}
+
+bool extract_forwarded_user(HTTPHeader &h, std::string &username)
+{
+    std::string forwarded = h.getXForwardedForIP();
+    if (forwarded.empty())
+        return false;
+
+    std::stringstream stream(forwarded);
+    std::string token;
+    std::string candidate;
+    while (std::getline(stream, token, ',')) {
+        std::string trimmed = trim_copy(token);
+        if (!trimmed.empty())
+            candidate = trimmed;
+    }
+
+    if (candidate.empty() || is_likely_ip(candidate))
+        return false;
+
+    username = candidate;
+    return true;
+}
 
 // IMPLEMENTATION
 
@@ -71,6 +148,7 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     if (user.length() < 1 || user == "-") {
         return E2AUTH_NOMATCH;
     }
+    user = normalise_auth_username(user);
     String u(user);
     String lastcategory;
     u.toLower(); // since the filtergroupslist is read in in lowercase, we should do this.

--- a/src/Auth.hpp
+++ b/src/Auth.hpp
@@ -16,6 +16,8 @@
 #include "ListContainer.hpp"
 #include "LOptionContainer.hpp"
 
+#include <string>
+
 // DEFINES
 
 // success
@@ -119,5 +121,13 @@ typedef AuthPlugin *authcreate_t(ConfigVar &);
 
 // Return an instance of the plugin defined in the given configuration file
 AuthPlugin *auth_plugin_load(const char *pluginConfigPath);
+
+// Normalise usernames prior to filter group lookups.  Removes domain prefixes
+// or Kerberos realms and trims surrounding whitespace.
+std::string normalise_auth_username(const std::string &raw);
+
+// Extract a forwarded identity from the X-Forwarded-For header when the
+// upstream proxy adds it as the last comma-separated value.
+bool extract_forwarded_user(HTTPHeader &h, std::string &username);
 
 #endif

--- a/src/authplugins/ProxyFirstBasic.cpp
+++ b/src/authplugins/ProxyFirstBasic.cpp
@@ -54,17 +54,27 @@ int pf_basic_instance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h
     // don't match for non-basic auth types
     String t(h.getAuthType());
     t.toLower();
-    if (t != "basic")
-        return E2AUTH_NOMATCH;
-    // extract username
-    string = h.getAuthData();
-    if (string.length() > 0) {
-        string.resize(string.find_first_of(':'));
+    if (t == "basic") {
+        // extract username
+        string = h.getAuthData();
+        if (string.length() > 0) {
+            string.resize(string.find_first_of(':'));
+            authrec.user_name = string;
+            authrec.user_source = "pf_basic";
+            is_real_user = true;
+            return E2AUTH_OK;
+        }
+    }
+
+    std::string forwarded_user;
+    if (extract_forwarded_user(h, forwarded_user)) {
+        string = forwarded_user;
         authrec.user_name = string;
-        authrec.user_source = "pf_basic";
-	is_real_user = true;
+        authrec.user_source = "forwarded";
+        is_real_user = true;
         return E2AUTH_OK;
     }
+
     return E2AUTH_NOMATCH;
 }
 

--- a/src/authplugins/ntlm.cpp
+++ b/src/authplugins/ntlm.cpp
@@ -172,6 +172,13 @@ int ntlminstance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h, std
     }
     String at(h.getAuthType());
 
+    if ((at != "NTLM") && extract_forwarded_user(h, string)) {
+        authrec.user_name = string;
+        authrec.user_source = "forwarded";
+        is_real_user = true;
+        return E2AUTH_OK;
+    }
+
 // First dance with NTLM - initial auth negociation -
     if (transparent && (at != "NTLM")) {
         // obey forwarded-for options in what we send out

--- a/src/authplugins/proxy.cpp
+++ b/src/authplugins/proxy.cpp
@@ -51,17 +51,27 @@ int proxyinstance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h, st
     // don't match for non-basic auth types
     String t(h.getAuthType());
     t.toLower();
-    if (t != "basic")
-        return E2AUTH_NOMATCH;
-    // extract username
-    string = h.getAuthData();
-    if (string.length() > 0) {
-        string.resize(string.find_first_of(':'));
+    if (t == "basic") {
+        // extract username
+        string = h.getAuthData();
+        if (string.length() > 0) {
+            string.resize(string.find_first_of(':'));
+            authrec.user_name = string;
+            authrec.user_source = "proxy";
+            is_real_user = true;
+            return E2AUTH_OK;
+        }
+    }
+
+    std::string forwarded_user;
+    if (extract_forwarded_user(h, forwarded_user)) {
+        string = forwarded_user;
         authrec.user_name = string;
-        authrec.user_source = "proxy";
-	is_real_user = true;
+        authrec.user_source = "forwarded";
+        is_real_user = true;
         return E2AUTH_OK;
     }
+
     return E2AUTH_NOMATCH;
 }
 


### PR DESCRIPTION
## Summary
- normalise usernames before evaluating filter group mappings to strip domain and realm noise
- add shared helpers to extract forwarded identities from X-Forwarded-For headers
- allow proxy-basic, pf-basic, and proxy-ntlm plugins to fall back to forwarded usernames when the proxy strips Proxy-Authorization data

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f43d051c20832e8566ea68e56618be