### PR TITLE
Ensure authplugins list directory exists during install

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST = domainsnobypass.in \
 
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(E2DATADIR)
+	$(MKDIR_P) $(DESTDIR)$(E2DATADIR)/authplugins
 	for l in $(SAMPLELISTS) ; do \
 		if test ! -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
 			echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \


### PR DESCRIPTION
## Summary
- ensure the lists/authplugins directory is created during installation so auth plugins can persist their configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f52fbcceac832e955fbbcdb09f6ba8