### PR TITLE
Normalize user map filter group names

### DIFF
--- a/src/LOptionContainer.cpp
+++ b/src/LOptionContainer.cpp
@@ -19,6 +19,8 @@
 #include <syslog.h>
 #include <dirent.h>
 #include <cstdlib>
+#include <map>
+#include <utility>
 #include <unistd.h> // checkme: remove?
 
 // GLOBALS
@@ -146,9 +148,72 @@ LOptionContainer::LOptionContainer(int load_id)
         else
             syslog(LOG_INFO, "Error in reading filter group files");
     }
+    if (loaded_ok)
+        normaliseAuthMapGroups();
     reload_id = load_id;
     ++o.LC_cnt;
     if (load_id == 0)    o.numfg = numfg;   // do this on first load only
+}
+
+void LOptionContainer::normaliseAuthMapGroups()
+{
+    std::map<std::string, int> name_lookup;
+
+    auto add_alias = [&](const String &label, int group_no) {
+        if (label.length() == 0)
+            return;
+        std::string key = normalise_group_label(label);
+        if (key.empty())
+            return;
+        if (name_lookup.find(key) == name_lookup.end())
+            name_lookup.emplace(std::move(key), group_no);
+    };
+
+    for (int idx = 0; idx < numfg; ++idx) {
+        if (fg[idx] == nullptr)
+            continue;
+
+        String base_name;
+        if (!fg[idx]->name.empty())
+            base_name = fg[idx]->name.c_str();
+        else {
+            base_name = "group";
+            base_name += String(idx + 1);
+        }
+
+        add_alias(base_name, idx + 1);
+        if (base_name.contains(" "))
+            add_alias(base_name.before(" "), idx + 1);
+
+        String alias("group");
+        alias += String(idx + 1);
+        add_alias(alias, idx + 1);
+
+        alias = "filter";
+        alias += String(idx + 1);
+        add_alias(alias, idx + 1);
+
+        alias = "grp";
+        alias += String(idx + 1);
+        add_alias(alias, idx + 1);
+
+        alias = String(idx + 1);
+        add_alias(alias, idx + 1);
+    }
+
+    if (name_lookup.empty())
+        return;
+
+    for (const auto &info : LMeta.list_vec) {
+        if (info.type != LIST_TYPE_MAP)
+            continue;
+        if (info.list_ref >= o.lm.l.size())
+            continue;
+        ListContainer *container = o.lm.l[info.list_ref];
+        if (container == nullptr)
+            continue;
+        container->normaliseDataMapGroups(name_lookup, info.name);
+    }
 }
 
 

--- a/src/LOptionContainer.hpp
+++ b/src/LOptionContainer.hpp
@@ -114,6 +114,7 @@ class LOptionContainer
 
     //bool inIPList(const std::string *ip, ListContainer &list, std::string *&host);
     std::list<room_item> rooms;
+    void normaliseAuthMapGroups();
 };
 
 #endif

--- a/src/ListContainer.cpp
+++ b/src/ListContainer.cpp
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <list>
+#include <map>
 #include <cctype>
 
 // GLOBALS
@@ -38,6 +39,84 @@ extern thread_local std::string thread_id;
 // DEFINES
 
 #define ROOTNODESIZE 260
+
+std::string normalise_group_label(const String &value)
+{
+    std::string result;
+    result.reserve(value.length());
+    for (unsigned char ch : value) {
+        if (std::isalnum(ch))
+            result.push_back(static_cast<char>(std::tolower(ch)));
+    }
+    return result;
+}
+
+namespace
+{
+
+int parse_group_number_token(const String &token)
+{
+    std::string digits;
+    bool seen_digit = false;
+    for (unsigned char ch : token) {
+        if (std::isdigit(ch)) {
+            digits.push_back(static_cast<char>(ch));
+            seen_digit = true;
+        } else if (seen_digit) {
+            break;
+        }
+    }
+    if (!seen_digit)
+        return 0;
+
+    String numeric_value(digits.c_str());
+    int number = numeric_value.toInteger();
+    if (number < 1 || number > o.filter_groups)
+        return 0;
+    return number;
+}
+
+int resolve_group_number(const String &value, const std::map<std::string, int> &name_lookup)
+{
+    if (value.length() == 0)
+        return 0;
+
+    int number = parse_group_number_token(value);
+    if (number > 0)
+        return number;
+
+    std::string key = normalise_group_label(value);
+    if (key.empty())
+        return 0;
+
+    auto direct = name_lookup.find(key);
+    if (direct != name_lookup.end())
+        return direct->second;
+
+    static const char *prefixes[] = {"filtergroup", "filter", "group", "grp"};
+    for (const char *prefix : prefixes) {
+        size_t prefix_len = std::strlen(prefix);
+        if (key.compare(0, prefix_len, prefix) != 0)
+            continue;
+
+        std::string remainder = key.substr(prefix_len);
+        if (remainder.empty())
+            continue;
+
+        String remainder_string(remainder.c_str());
+        number = parse_group_number_token(remainder_string);
+        if (number > 0)
+            return number;
+
+        auto alias = name_lookup.find(remainder);
+        if (alias != name_lookup.end())
+            return alias->second;
+    }
+
+    return 0;
+}
+
+} // namespace
 #define MAXROOTLINKS ROOTNODESIZE - 4
 #define GRAPHENTRYSIZE 64
 #define MAXLINKS GRAPHENTRYSIZE - 4
@@ -1985,6 +2064,40 @@ const String *ListContainer::getMapData(String &key) {
     if (datamaplist.empty())
         return nullptr;
     return searchDataMap(0, datamaplist.size() - 1, key);
+}
+
+void ListContainer::normaliseDataMapGroups(const std::map<std::string, int> &name_lookup, const String &list_name)
+{
+    if (!is_map || is_iplist)
+        return;
+
+    bool modified = false;
+    for (auto &entry : datamaplist) {
+        if (entry.group.length() == 0)
+            continue;
+
+        int resolved = resolve_group_number(entry.group, name_lookup);
+        if (resolved > 0) {
+            if (entry.group.toInteger() != resolved) {
+                entry.group = String(resolved);
+                modified = true;
+            }
+            continue;
+        }
+
+        if (!is_daemonised) {
+            std::cerr << thread_id << "Unable to resolve filter group '" << entry.group
+                      << "' for entry " << entry.key << " in list " << list_name
+                      << " (" << sourcefile << ")" << std::endl;
+        }
+        syslog(LOG_ERR, "Unable to resolve filter group '%s' for entry %s in %s (%s)",
+               entry.group.toCharArray(), entry.key.toCharArray(), list_name.toCharArray(), sourcefile.c_str());
+        entry.group.clear();
+        modified = true;
+    }
+
+    if (modified)
+        std::stable_sort(datamaplist.begin(), datamaplist.end());
 }
 
 const String *ListContainer::getIPMapData(std::string &ip) {

--- a/src/ListContainer.hpp
+++ b/src/ListContainer.hpp
@@ -20,6 +20,8 @@
 
 // DECLARATIONS
 
+std::string normalise_group_label(const String &value);
+
 // time limit information
 struct TimeLimit {
     unsigned int sthour, stmin, endhour, endmin;
@@ -273,6 +275,7 @@ class ListContainer
     const char *hIPtoChar(uint32_t ip);
     const String *inIPMap(const uint32_t &ip);
     const String *getMapData(String &key);
+    void normaliseDataMapGroups(const std::map<std::string, int> &name_lookup, const String &list_name);
 };
 
 #endif


### PR DESCRIPTION
## Summary
- resolve filter group references in auth map lists even when users specify textual group names
- normalize map entries during configuration load so proxy-basic authentication respects configured group assignments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f54c89e28c832e9ce8741136067c56