### PR TITLE
Tratar alias de grupo default em listas de autenticação

### DIFF
--- a/src/LOptionContainer.cpp
+++ b/src/LOptionContainer.cpp
@@ -201,6 +201,14 @@ void LOptionContainer::normaliseAuthMapGroups()
         add_alias(alias, idx + 1);
     }
 
+    int default_group = 1;
+    if (o.default_fg >= 0 && o.default_fg < numfg)
+        default_group = o.default_fg + 1;
+
+    add_alias(String("default"), default_group);
+    add_alias(String("defaultgroup"), default_group);
+    add_alias(String("defaultfiltergroup"), default_group);
+
     if (name_lookup.empty())
         return;
 


### PR DESCRIPTION
## Summary
- adiciona aliases automáticos para o grupo default ao normalizar as listas de mapeamento de usuários
- garante que valores como "default" sejam resolvidos para o número de grupo correto

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5619fe3ec832eb72072cb9affb687