### PR TITLE
Allow proxy-basic auth to accept forwarded headers

### DIFF
--- a/src/authplugins/proxy.cpp
+++ b/src/authplugins/proxy.cpp
@@ -51,15 +51,23 @@ int proxyinstance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h, st
     // don't match for non-basic auth types
     String t(h.getAuthType());
     t.toLower();
-    if (t == "basic") {
-        // extract username
-        string = h.getAuthData();
-        if (string.length() > 0) {
-            string.resize(string.find_first_of(':'));
-            authrec.user_name = string;
-            authrec.user_source = "proxy";
-            is_real_user = true;
-            return E2AUTH_OK;
+
+    std::string authdata = h.getAuthData();
+    if ((t == "basic") || (t.length() == 0)) {
+        // Proxy-Authorization headers forwarded by Squid via cache_peer may
+        // not be flagged internally as originating from a proxy.  In that
+        // situation we still want to honour the header so that the user can
+        // be mapped to the correct filter group.
+        if (!authdata.empty()) {
+            std::string::size_type separator = authdata.find(':');
+            if (separator != std::string::npos) {
+                // extract username
+                string = authdata.substr(0, separator);
+                authrec.user_name = string;
+                authrec.user_source = "proxy";
+                is_real_user = true;
+                return E2AUTH_OK;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- update the proxy auth plugin to accept Proxy-Authorization headers even when they are not marked as proxy-sourced
- ensure users forwarded by Squid via cache_peer can still be mapped to the right filter group

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f583a3a818832e87f3930154369a3f