### PR TITLE
Add proxy-basic authentication debug tracing

### DIFF
--- a/src/Auth.cpp
+++ b/src/Auth.cpp
@@ -18,6 +18,7 @@
 #include <syslog.h>
 #include <algorithm>
 #include <cctype>
+#include <cstdarg>
 #include <sstream>
 #include <arpa/inet.h>
 
@@ -73,8 +74,38 @@ bool is_likely_ip(const std::string &token)
 }
 }
 
+thread_local bool proxy_basic_debug_scope_flag = false;
+
+void proxy_basic_debug_log(const char *fmt, ...)
+{
+    if (!proxy_basic_debug_scope_flag)
+        return;
+
+    std::string format = "[PROXYBASIC_DEBUG] ";
+    format += fmt;
+
+    va_list args;
+    va_start(args, fmt);
+    vsyslog(LOG_INFO, format.c_str(), args);
+    va_end(args);
+}
+
+ProxyBasicDebugScope::ProxyBasicDebugScope(bool enable)
+    : previous_(proxy_basic_debug_scope_flag)
+{
+    if (enable)
+        proxy_basic_debug_scope_flag = true;
+}
+
+ProxyBasicDebugScope::~ProxyBasicDebugScope()
+{
+    proxy_basic_debug_scope_flag = previous_;
+}
+
 std::string normalise_auth_username(const std::string &raw)
 {
+    proxy_basic_debug_log("%sRecebido usuario bruto para normalizacao: '%s'", thread_id.c_str(), raw.c_str());
+
     std::string result = trim_copy(raw);
     if (result.empty())
         return result;
@@ -91,28 +122,45 @@ std::string normalise_auth_username(const std::string &raw)
     if (result.size() > 1 && ((result.front() == '"' && result.back() == '"') || (result.front() == '\'' && result.back() == '\'')))
         result = result.substr(1, result.size() - 2);
 
-    return trim_copy(result);
+    result = trim_copy(result);
+
+    proxy_basic_debug_log("%sUsuario apos normalizacao sem alterar caixa: '%s'", thread_id.c_str(), result.c_str());
+
+    return result;
 }
 
 bool extract_forwarded_user(HTTPHeader &h, std::string &username)
 {
     std::string forwarded = h.getXForwardedForIP();
-    if (forwarded.empty())
+    proxy_basic_debug_log("%sCabecalho X-Forwarded-For bruto: '%s'", thread_id.c_str(), forwarded.c_str());
+
+    if (forwarded.empty()) {
+        proxy_basic_debug_log("%sCabecalho X-Forwarded-For ausente ou vazio", thread_id.c_str());
         return false;
+    }
 
     std::stringstream stream(forwarded);
     std::string token;
     std::string candidate;
     while (std::getline(stream, token, ',')) {
         std::string trimmed = trim_copy(token);
+        proxy_basic_debug_log("%sToken X-Forwarded-For analisado: '%s'", thread_id.c_str(), trimmed.c_str());
         if (!trimmed.empty())
             candidate = trimmed;
     }
 
-    if (candidate.empty() || is_likely_ip(candidate))
+    if (candidate.empty()) {
+        proxy_basic_debug_log("%sNenhum candidato encontrado no cabecalho X-Forwarded-For", thread_id.c_str());
         return false;
+    }
+
+    if (is_likely_ip(candidate)) {
+        proxy_basic_debug_log("%sUltimo token do X-Forwarded-For parece um IP ('%s'), ignorando", thread_id.c_str(), candidate.c_str());
+        return false;
+    }
 
     username = candidate;
+    proxy_basic_debug_log("%sUsuario extraido do X-Forwarded-For: '%s'", thread_id.c_str(), username.c_str());
     return true;
 }
 
@@ -145,7 +193,10 @@ String AuthPlugin::getPluginName()
 // return -1 when user not found
 int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, NaughtyFilter &cm )
 {
+    proxy_basic_debug_log("%sInicio determineGroup para plugin '%s' com usuario bruto '%s'", thread_id.c_str(),
+                          pluginName.toCharArray(), user.c_str());
     if (user.length() < 1 || user == "-") {
+        proxy_basic_debug_log("%sUsuario invalido para determineGroup (vazio ou '-')", thread_id.c_str());
         return E2AUTH_NOMATCH;
     }
     user = normalise_auth_username(user);
@@ -153,6 +204,7 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     String lastcategory;
     u.toLower(); // since the filtergroupslist is read in in lowercase, we should do this.
     user = u.toCharArray(); // also pass back to ConnectionHandler, so appears lowercase in logs
+    proxy_basic_debug_log("%sUsuario apos conversao para minusculas: '%s'", thread_id.c_str(), user.c_str());
     //  String ue(u);
     //  ue += "=";
 
@@ -163,6 +215,7 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
         int t = get_default(!cm.request_header->isProxyRequest);
         if (t > 0) {
             fg = --t;
+            proxy_basic_debug_log("%sUsuario nao encontrado; aplicando grupo padrao %d", thread_id.c_str(), fg);
             if (cm.authrec != nullptr) {
                 cm.authrec->filter_group = fg;
                 cm.authrec->group_source = "pdef";
@@ -174,6 +227,8 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
 #ifdef E2DEBUG
         std::cerr << "User not in filter groups list for: " << pluginName.c_str() << std::endl;
 #endif
+        proxy_basic_debug_log("%sUsuario nao localizado em listas de grupos para plugin '%s'", thread_id.c_str(),
+                              pluginName.toCharArray());
         return E2AUTH_NOGROUP;
     }
 
@@ -181,6 +236,7 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     std::cerr << "Group found for: " << user.c_str() << " in " << pluginName.c_str() << std::endl;
 #endif
     fg = cm.filtergroup;
+    proxy_basic_debug_log("%sUsuario associado ao grupo %d pelo plugin '%s'", thread_id.c_str(), fg, pluginName.toCharArray());
     if (cm.authrec != nullptr) {
         cm.authrec->filter_group = fg;
         if (cm.authrec->user_name.length() == 0)

--- a/src/Auth.hpp
+++ b/src/Auth.hpp
@@ -130,4 +130,16 @@ std::string normalise_auth_username(const std::string &raw);
 // upstream proxy adds it as the last comma-separated value.
 bool extract_forwarded_user(HTTPHeader &h, std::string &username);
 
+// Debug helpers for proxy-basic tracing.
+void proxy_basic_debug_log(const char *fmt, ...);
+
+class ProxyBasicDebugScope {
+public:
+    explicit ProxyBasicDebugScope(bool enable);
+    ~ProxyBasicDebugScope();
+
+private:
+    bool previous_;
+};
+
 #endif

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -9,7 +9,7 @@
 #include "ConnectionHandler.hpp"
 #include "DataBuffer.hpp"
 #include "UDSocket.hpp"
-//#include "Auth.hpp"
+#include "Auth.hpp"
 #include "FDTunnel.hpp"
 #include "BackedStore.hpp"
 #include "Queue.hpp"
@@ -58,6 +58,32 @@ extern OptionContainer o;
 extern bool is_daemonised;
 extern std::atomic<bool> ttg;
 extern thread_local std::string thread_id;
+
+
+namespace {
+
+bool has_proxy_basic_plugin()
+{
+    for (auto it = o.authplugins_begin; it != o.authplugins_end; ++it) {
+        AuthPlugin *plugin = static_cast<AuthPlugin *>(*it);
+        if (plugin == nullptr)
+            continue;
+        String name = plugin->getPluginName();
+        if (name.startsWith("proxy-basic"))
+            return true;
+    }
+    return false;
+}
+
+bool is_proxy_basic_plugin(AuthPlugin *plugin)
+{
+    if (plugin == nullptr)
+        return false;
+    String name = plugin->getPluginName();
+    return name.startsWith("proxy-basic");
+}
+
+}
 
 
 // IMPLEMENTATION
@@ -503,11 +529,16 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
 
     sock.setTimeout(o.connect_timeout);
 
+    proxy_basic_debug_log("%sTentando conectar ao destino %s:%d (isdirect=%d)", thread_id.c_str(),
+                          cm.connect_site.toCharArray(), port, cm.isdirect);
+
     while (++retry < o.connect_retries) {
         lerr_mess = 0;
         if (retry > 0) {
             if (o.logconerror)
                 syslog(LOG_INFO, "%s retry %d to connect to %s", thread_id.c_str(), retry, cm.urldomain.c_str());
+            proxy_basic_debug_log("%sRe-tentativa %d para conectar ao destino %s:%d", thread_id.c_str(), retry,
+                                  cm.connect_site.toCharArray(), port);
             if (!sock.isTimedout())
                 usleep(1000);       // don't hammer upstream
         }
@@ -538,11 +569,15 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
 #ifdef E2DEBUG
                 std::cerr << thread_id << "Connecting to IP " << des_ip << " port " << port << std::endl;
 #endif
+                proxy_basic_debug_log("%sConectando diretamente para %s:%d", thread_id.c_str(), des_ip.toCharArray(), port);
                 int rc = sock.connect(des_ip, port);
                 if (rc < 0) {
                     lerr_mess = 203;
+                    proxy_basic_debug_log("%sFalha ao conectar diretamente para %s:%d (rc=%d)", thread_id.c_str(),
+                                          des_ip.toCharArray(), port, rc);
                     continue;
                 }
+                proxy_basic_debug_log("%sConexao direta estabelecida com %s:%d", thread_id.c_str(), des_ip.toCharArray(), port);
                 return rc;
             } else {
                 //dns lookup
@@ -608,14 +643,17 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
                     std::cerr << thread_id << "Connecting to IP " << t << " port " <<
                     port << " after dns lookup" << std::endl;
 #endif
+                    proxy_basic_debug_log("%sConectando para %s:%d apos DNS", thread_id.c_str(), t, port);
                     int rc = sock.connect(t, port);
                     if (rc == 0) {
                         freeaddrinfo(infoptr);
 #ifdef E2DEBUG
                         std::cerr << thread_id << "Got connection upfailure is " << cm.upfailure << std::endl;
 #endif
+                        proxy_basic_debug_log("%sConexao estabelecida apos DNS para %s:%d", thread_id.c_str(), t, port);
                         return 0;
                     }
+                    proxy_basic_debug_log("%sFalha ao conectar apos DNS para %s:%d (rc=%d)", thread_id.c_str(), t, port, rc);
                 }
                 freeaddrinfo(infoptr);
                 if (may_be_loop) break;
@@ -624,14 +662,19 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
             }
         } else {  //is via proxy
             sock.setTimeout(o.proxy_timeout);
+            proxy_basic_debug_log("%sConectando ao proxy pai %s:%d", thread_id.c_str(), o.proxy_ip.c_str(), o.proxy_port);
             int rc = sock.connect(o.proxy_ip, o.proxy_port);
             if (rc < 0) {
                 if (sock.isTimedout())
                     lerr_mess = 201;
                 else
                     lerr_mess = 202;
+                proxy_basic_debug_log("%sFalha ao conectar ao proxy pai %s:%d (rc=%d)", thread_id.c_str(),
+                                      o.proxy_ip.c_str(), o.proxy_port, rc);
                 continue;
             }
+            proxy_basic_debug_log("%sConexao estabelecida com proxy pai %s:%d", thread_id.c_str(), o.proxy_ip.c_str(),
+                                  o.proxy_port);
             return rc;
         }
     }
@@ -647,6 +690,8 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
     cm.blocktype = 3;
     cm.isexception = false;
     cm.isbypass = false;
+    proxy_basic_debug_log("%sTodas as tentativas de saida falharam para %s:%d (codigo %d)", thread_id.c_str(),
+                          cm.connect_site.toCharArray(), port, lerr_mess);
     return -1;
 }
 
@@ -692,6 +737,8 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
     struct timeval thestart;
     gettimeofday(&thestart, NULL);
 
+    ProxyBasicDebugScope proxy_basic_scope(has_proxy_basic_plugin());
+
     //peerconn.setTimeout(o.proxy_timeout);
     peerconn.setTimeout(o.pcon_timeout);
 
@@ -714,6 +761,8 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
     std::deque<CSPlugin *> responsescanners;
 
     std::string clientip(ip.toCharArray()); // hold the clients ip
+    proxy_basic_debug_log("%sRecebida nova conexao do cache-peer %s (ismitm=%d)", thread_id.c_str(),
+                          clientip.c_str(), ismitm ? 1 : 0);
     header.setClientIP(ip);
 
     if (clienthost) delete clienthost;
@@ -787,6 +836,7 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
             persistPeer = false;
         } else {
             ++dystat->reqs;
+            proxy_basic_debug_log("%sCabecalho HTTP recebido da conexao do cache-peer", thread_id.c_str());
         }
         //
         // End of set-up section
@@ -865,6 +915,13 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
 //
             // do this normalisation etc just the once at the start.
             checkme.setURL(ismitm);
+            String request_method(header.requestType());
+            proxy_basic_debug_log("%sResumo da requisicao: metodo='%s' url='%s' proxy=%d", thread_id.c_str(),
+                                  request_method.toCharArray(), checkme.url.c_str(), header.isProxyRequest);
+            proxy_basic_debug_log("%sCabecalho Proxy-Authorization bruto: '%s'", thread_id.c_str(),
+                                  header.getRawAuthData().c_str());
+            proxy_basic_debug_log("%sCabecalho X-Forwarded-For recebido: '%s'", thread_id.c_str(),
+                                  header.getXForwardedForIP().c_str());
 
             if(o.log_requests) {
                 std::string fnt;
@@ -2967,6 +3024,10 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
             // Logic changed to allow auth scan with multiple ports as option to auth-port
             //       fixed mapping
             //
+            bool plugin_is_proxy_basic = is_proxy_basic_plugin(auth_plugin);
+            if (plugin_is_proxy_basic)
+                proxy_basic_debug_log("%sConsultando plugin proxy-basic para identificar usuario", thread_id.c_str());
+
             if (o.map_auth_to_ports) {
                 if (o.filter_ports.size() > 1) {
                     tmp = o.auth_map[peerconn.getPort()];
@@ -2986,6 +3047,8 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
             }
 
             if (rc == E2AUTH_NOMATCH) {
+                if (plugin_is_proxy_basic)
+                    proxy_basic_debug_log("%sPlugin proxy-basic nao encontrou credenciais nesta tentativa", thread_id.c_str());
 #ifdef E2DEBUG
                 std::cerr << "Auth plugin did not find a match; querying remaining plugins" << std::endl;
 #endif
@@ -3012,20 +3075,30 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
                 std::cerr << "Auth plugin  returned OK but no persist not setting persist auth" << std::endl;
 #endif
                 overide_persist = true;
+                if (plugin_is_proxy_basic)
+                    proxy_basic_debug_log("%sPlugin proxy-basic autenticou sem persistencia", thread_id.c_str());
             } else if (rc < 0) {
                 if (!is_daemonised)
                     std::cerr << thread_id << "Auth plugin returned error code: " << rc << std::endl;
                 syslog(LOG_ERR, "%sAuth plugin returned error code: %d", thread_id.c_str(), rc);
+                if (plugin_is_proxy_basic)
+                    proxy_basic_debug_log("%sPlugin proxy-basic retornou erro %d", thread_id.c_str(), rc);
                 dobreak = true;
                 break;
             }
 #ifdef E2DEBUG
             std::cerr << thread_id << " -Auth plugin found username " << clientuser << " (" << oldclientuser << "), now determining group" << std::endl;
 #endif
+            if (plugin_is_proxy_basic)
+                proxy_basic_debug_log("%sPlugin proxy-basic retornou usuario '%s' (anterior '%s'); iniciando determineGroup",
+                                      thread_id.c_str(), clientuser.c_str(), oldclientuser.c_str());
             if (clientuser == oldclientuser) {
 #ifdef E2DEBUG
                 std::cerr << thread_id << " -Same user as last time, re-using old group no." << std::endl;
 #endif
+                if (plugin_is_proxy_basic)
+                    proxy_basic_debug_log("%sPlugin proxy-basic indicou mesmo usuario anterior; reutilizando grupo %d",
+                                          thread_id.c_str(), oldfg);
                 authed = true;
                 filtergroup = oldfg;
                 break;
@@ -3036,6 +3109,9 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
 #ifdef E2DEBUG
                 std::cerr << thread_id << "Auth plugin found username & group; not querying remaining plugins" << std::endl;
 #endif
+                if (plugin_is_proxy_basic)
+                    proxy_basic_debug_log("%sPlugin proxy-basic associou usuario '%s' ao grupo %d", thread_id.c_str(),
+                                          clientuser.c_str(), filtergroup);
                 authed = true;
                 break;
             } else if (rc == E2AUTH_NOMATCH) {

--- a/src/authplugins/ProxyFirstBasic.cpp
+++ b/src/authplugins/ProxyFirstBasic.cpp
@@ -56,29 +56,38 @@ AuthPlugin *PF_basic_create(ConfigVar &definition)
 int pf_basic_instance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h, std::string &string, bool &is_real_user, auth_rec &authrec)
 {
     // don't match for non-basic auth types
-    String t(h.getAuthType());
+    String raw_type(h.getAuthType());
+    proxy_basic_debug_log("%sIniciando identify do proxy-basic: auth_type='%s' raw_auth='%s'", thread_id.c_str(),
+                          raw_type.toCharArray(), h.getRawAuthData().c_str());
+
+    String t(raw_type);
     t.toLower();
     if (t == "basic") {
         // extract username
         string = h.getAuthData();
+        proxy_basic_debug_log("%sCredencial BASIC decodificada: '%s'", thread_id.c_str(), string.c_str());
         if (string.length() > 0) {
             string.resize(string.find_first_of(':'));
             authrec.user_name = string;
             authrec.user_source = "pf_basic";
             is_real_user = true;
+            proxy_basic_debug_log("%sUsuario obtido do cabecalho Proxy-Authorization: '%s'", thread_id.c_str(), string.c_str());
             return E2AUTH_OK;
         }
     }
 
+    proxy_basic_debug_log("%sTentando extrair usuario do cabecalho X-Forwarded-For", thread_id.c_str());
     std::string forwarded_user;
     if (extract_forwarded_user(h, forwarded_user)) {
         string = forwarded_user;
         authrec.user_name = string;
         authrec.user_source = "forwarded";
         is_real_user = true;
+        proxy_basic_debug_log("%sUsuario obtido do X-Forwarded-For: '%s'", thread_id.c_str(), string.c_str());
         return E2AUTH_OK;
     }
 
+    proxy_basic_debug_log("%sNenhuma credencial valida encontrada para proxy-basic", thread_id.c_str());
     return E2AUTH_NOMATCH;
 }
 
@@ -87,13 +96,18 @@ int pf_basic_instance::determineGroup(std::string &user, int &rfg, StoryBoard &s
     if (user.length() < 1 || user == "-")
         return E2AUTH_NOMATCH;
 
+    proxy_basic_debug_log("%sdetermineGroup (proxy-basic) recebeu usuario '%s'", thread_id.c_str(), user.c_str());
     std::string normalised = normalise_auth_username(user);
     if (normalised.empty())
         return E2AUTH_NOMATCH;
 
+    proxy_basic_debug_log("%sUsuario apos normalizacao (antes do lower-case): '%s'", thread_id.c_str(), normalised.c_str());
     String lowered(normalised.c_str());
     lowered.toLower();
     user = lowered.toCharArray();
+
+    proxy_basic_debug_log("%sUsuario apos conversao para minusculas no determineGroup do proxy-basic: '%s'",
+                          thread_id.c_str(), user.c_str());
 
     cm.user = user;
 
@@ -102,6 +116,7 @@ int pf_basic_instance::determineGroup(std::string &user, int &rfg, StoryBoard &s
         if (default_group > 0) {
             rfg = default_group - 1;
             cm.filtergroup = rfg;
+            proxy_basic_debug_log("%sUsuario nao localizado; aplicando grupo padrao %d no proxy-basic", thread_id.c_str(), rfg);
             if (cm.authrec != nullptr) {
                 cm.authrec->group_source = cv["plugname"];
                 cm.authrec->filter_group = rfg;
@@ -113,10 +128,12 @@ int pf_basic_instance::determineGroup(std::string &user, int &rfg, StoryBoard &s
 #ifdef E2DEBUG
         std::cerr << thread_id << "User not in filter groups list for: " << cv["plugname"].c_str() << std::endl;
 #endif
+        proxy_basic_debug_log("%sUsuario '%s' nao encontrado nas listas do proxy-basic", thread_id.c_str(), user.c_str());
         return E2AUTH_NOGROUP;
     }
 
     rfg = cm.filtergroup;
+    proxy_basic_debug_log("%sUsuario '%s' associado ao grupo %d pelo proxy-basic", thread_id.c_str(), user.c_str(), rfg);
     if (cm.authrec != nullptr) {
         cm.authrec->group_source = cv["plugname"];
         cm.authrec->filter_group = rfg;


### PR DESCRIPTION
## Summary
- add a proxy-basic debug logging scope that writes tagged messages to syslog
- instrument the proxy-basic auth plugin, username normalisation, and connection handler to log each step
- trace upstream connection attempts so the entire proxy-basic flow is observable end-to-end

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5942bf6e8832eaf374687469710eb