### PR TITLE
Handle alias labels when resolving filter groups

### DIFF
--- a/notes/proxy-basic-analysis.md
+++ b/notes/proxy-basic-analysis.md
@@ -1,0 +1,13 @@
+# Proxy-Basic: comportamento da resolução de grupos
+
+Nos testes reportados, o e2guardian autenticou o usuário via plug-in `proxy-basic`, mas o filtro resultante caiu sempre no primeiro grupo configurado (ou no valor definido em `defaultfiltergroup`). A revisão do código confirma que:
+
+- A função `auth_proxy_basic`, chamada pelo plug-in, apenas consulta a lista `defaultusermap` e encerra a avaliação se o usuário não estiver presente nela. Nenhum fallback consulta o `ipmap` ou outras listas. 【F:configs/preauth.story†L40-L57】
+- O arquivo `proxy-basic.conf` explica que definir `defaultfiltergroup` garante que o plug-in sempre encontrará um grupo, mesmo se o usuário não estiver na lista de grupos. Isso reproduz o comportamento visto nos logs. 【F:configs/authplugins/proxy-basic.conf†L1-L23】
+
+## Ajustes sugeridos
+
+1. Duplicar a lógica sugerida nos comentários de `preauth.story`, acrescentando um fallback que consulte `ipmap` (ou outra lista apropriada) quando a busca em `defaultusermap` falhar.
+2. Alternativamente, garantir que o usuário conste em `filtergroupslist`/`defaultusermap` para que o plug-in encontre o grupo correto sem recorrer ao fallback.
+
+Os logs mencionados demonstram exatamente essa ausência de correspondência na lista de usuários: após a autenticação, o mecanismo não encontra entrada no `defaultusermap` e retorna imediatamente, fazendo com que a seleção de grupo caia nos valores padrão.

--- a/src/StoryBoard.cpp
+++ b/src/StoryBoard.cpp
@@ -20,6 +20,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <ctime>
+#include <cctype>
+#include <memory>
 #include <unistd.h>
 #include <iostream>
 #include <fstream>
@@ -37,6 +39,88 @@ extern thread_local std::string thread_id;
 // DEFINES
 
 //#define SBDEBUG
+
+namespace
+{
+
+int resolve_filter_group_from_label(const String &label)
+{
+    if (label.length() == 0)
+        return 0;
+
+    String trimmed(label);
+    trimmed.removeWhiteSpace();
+    if (trimmed.length() == 0)
+        return 0;
+
+    int numeric = trimmed.toInteger();
+    if (numeric >= 1 && numeric <= o.numfg)
+        return numeric;
+
+    String lowered(trimmed);
+    lowered.toLower();
+
+    if (lowered == "default" || lowered == "defaultgroup" || lowered == "defaultfiltergroup") {
+        int default_group = 1;
+        if (o.default_fg >= 0 && o.default_fg < o.numfg)
+            default_group = o.default_fg + 1;
+        return default_group;
+    }
+
+    std::string normalised = normalise_group_label(lowered);
+    if (normalised.empty())
+        return 0;
+
+    String numeric_candidate(normalised.c_str());
+    numeric = numeric_candidate.toInteger();
+    if (numeric >= 1 && numeric <= o.numfg)
+        return numeric;
+
+    std::string digits;
+    for (unsigned char ch : normalised) {
+        if (std::isdigit(ch))
+            digits.push_back(static_cast<char>(ch));
+        else if (!digits.empty())
+            break;
+    }
+    if (!digits.empty()) {
+        String digit_string(digits.c_str());
+        numeric = digit_string.toInteger();
+        if (numeric >= 1 && numeric <= o.numfg)
+            return numeric;
+    }
+
+    std::shared_ptr<LOptionContainer> lists = o.currentLists();
+    if (lists != nullptr) {
+        for (int idx = 0; idx < lists->numfg; ++idx) {
+            if (lists->fg == nullptr || lists->fg[idx] == nullptr)
+                continue;
+
+            String base_name;
+            if (!lists->fg[idx]->name.empty())
+                base_name = lists->fg[idx]->name.c_str();
+            else {
+                base_name = "group";
+                base_name += String(idx + 1);
+            }
+
+            std::string base_normalised = normalise_group_label(base_name);
+            if (!base_normalised.empty() && normalised == base_normalised)
+                return idx + 1;
+
+            if (base_name.contains(" ")) {
+                String first_token(base_name.before(" "));
+                std::string token_normalised = normalise_group_label(first_token);
+                if (!token_normalised.empty() && normalised == token_normalised)
+                    return idx + 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+} // namespace
 
 // Constructor - set default values
 StoryBoard::StoryBoard() {
@@ -826,14 +910,15 @@ bool StoryBoard::runFunct(unsigned int fID, NaughtyFilter &cm) {
                     break;
                 case SB_FUNC_SETGROUP:
                     action_return = false;
-                    if (cm.result.size() > 0) {
-                        int g = cm.result.toInteger();
+                    {
+                        int g = resolve_filter_group_from_label(cm.result);
                         if (g > 0 && g <= o.numfg) {
-                            cm.filtergroup = --g;
-                            cm.authrec->group_source = i->list_name;
+                            cm.filtergroup = g - 1;
+                            if (cm.authrec != nullptr)
+                                cm.authrec->group_source = i->list_name;
                             action_return = true;
                         }
-                    };
+                    }
                     break;
                 case SB_FUNC_UNSETVIRUSCHECK:
                     cm.noviruscheck = true;


### PR DESCRIPTION
## Summary
- make storyboard setgroup resolve filter-group labels like `filter3` or named groups
- reuse the active filter-group definitions when translating map entries into group numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f65ef939e4832ebbf9997a90fff766