### PR TITLE
Route debug trace logs to shared file

### DIFF
--- a/src/Auth.cpp
+++ b/src/Auth.cpp
@@ -84,9 +84,24 @@ bool is_likely_ip(const std::string &token)
 
 namespace
 {
-constexpr const char *kProxyBasicDebugLogPath = "/var/log/e2guardian/debug.log";
-std::mutex proxy_basic_debug_mutex;
-int proxy_basic_debug_fd = -1;
+constexpr const char *kDebugLogPath = "/var/log/e2guardian/debug.log";
+std::mutex debug_log_mutex;
+int debug_log_fd = -1;
+
+void append_debug_log(const std::string &message)
+{
+    std::lock_guard<std::mutex> lock(debug_log_mutex);
+    if (debug_log_fd == -1) {
+        debug_log_fd = open(kDebugLogPath, O_WRONLY | O_CREAT | O_APPEND, 0640);
+        if (debug_log_fd == -1) {
+            syslog(LOG_ERR, "%sUnable to open %s for debug logging: %s", thread_id.c_str(), kDebugLogPath, strerror(errno));
+            return;
+        }
+    }
+
+    ssize_t ignored = write(debug_log_fd, message.c_str(), message.size());
+    (void)ignored;
+}
 }
 
 thread_local bool proxy_basic_debug_scope_flag = false;
@@ -124,18 +139,41 @@ void proxy_basic_debug_log(const char *fmt, ...)
     formatted += message;
     formatted.push_back('\n');
 
-    std::lock_guard<std::mutex> lock(proxy_basic_debug_mutex);
-    if (proxy_basic_debug_fd == -1) {
-        proxy_basic_debug_fd = open(kProxyBasicDebugLogPath, O_WRONLY | O_CREAT | O_APPEND, 0640);
-        if (proxy_basic_debug_fd == -1) {
-            syslog(LOG_ERR, "%sUnable to open %s for proxy-basic debug logging: %s", thread_id.c_str(),
-                   kProxyBasicDebugLogPath, strerror(errno));
-            return;
-        }
-    }
+    append_debug_log(formatted);
+}
 
-    ssize_t ignored = write(proxy_basic_debug_fd, formatted.c_str(), formatted.size());
-    (void)ignored;
+// [GROUPTRACE_DEBUG] Emite mensagens de rastreamento sobre atribuicao de grupos.
+void group_trace_debug_log(const char *fmt, ...)
+{
+    char stack_buffer[1024];
+    va_list args;
+    va_start(args, fmt);
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int needed = vsnprintf(stack_buffer, sizeof(stack_buffer), fmt, args_copy);
+    va_end(args_copy);
+
+    std::string message;
+    if (needed < 0) {
+        message = "Falha ao formatar mensagem de rastreamento de grupos";
+    } else if (static_cast<size_t>(needed) < sizeof(stack_buffer)) {
+        message.assign(stack_buffer, static_cast<size_t>(needed));
+    } else {
+        std::vector<char> dynamic_buffer(static_cast<size_t>(needed) + 1, '\0');
+        va_list args_retry;
+        va_copy(args_retry, args);
+        vsnprintf(dynamic_buffer.data(), dynamic_buffer.size(), fmt, args_retry);
+        va_end(args_retry);
+        message.assign(dynamic_buffer.data());
+    }
+    va_end(args);
+
+    std::string tagged_message = std::string("[GROUPTRACE_DEBUG] ") + message;
+    std::string formatted = thread_id + tagged_message + '\n';
+    if (!is_daemonised) {
+        std::cerr << formatted << std::flush;
+    }
+    append_debug_log(formatted);
 }
 
 ProxyBasicDebugScope::ProxyBasicDebugScope(bool enable)
@@ -264,6 +302,16 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     user = u.toCharArray(); // also pass back to ConnectionHandler, so appears lowercase in logs
     // [PROXYBASIC_DEBUG] Registrando usuario apos conversao para minusculas.
     proxy_basic_debug_log("%sUsuario apos conversao para minusculas: '%s'", thread_id.c_str(), user.c_str());
+    std::string entry_function_name;
+    std::string entry_file_name;
+    unsigned int entry_index = story_entry >= 0 ? static_cast<unsigned int>(story_entry) : 0;
+    bool has_entry_info = story_entry >= 0 && story.getEntryDebugInfo(entry_index, entry_function_name, entry_file_name);
+    const char *function_label = (has_entry_info && !entry_function_name.empty()) ? entry_function_name.c_str() : "<desconhecido>";
+    const char *file_label = (has_entry_info && !entry_file_name.empty()) ? entry_file_name.c_str() : "<desconhecido>";
+    int fg_before_lookup = fg;
+    // [GROUPTRACE_DEBUG] Inicio do rastreamento da determinacao de grupo.
+    group_trace_debug_log("Plugin '%s' avaliara usuario '%s' usando entrada %d (funcao='%s', arquivo='%s', fg_atual=%d)",
+                         pluginName.toCharArray(), user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     //  String ue(u);
     //  ue += "=";
 
@@ -276,6 +324,9 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
             fg = --t;
             // [PROXYBASIC_DEBUG] Indicando aplicacao do grupo padrao por falta de correspondencia.
             proxy_basic_debug_log("%sUsuario nao encontrado; aplicando grupo padrao %d", thread_id.c_str(), fg);
+            // [GROUPTRACE_DEBUG] Nenhuma correspondencia encontrada; aplicando grupo padrao.
+            group_trace_debug_log("Plugin '%s' nao encontrou grupo para '%s' (entrada %d, funcao='%s', arquivo='%s'); usando padrao=%d",
+                                  pluginName.toCharArray(), user.c_str(), story_entry, function_label, file_label, fg);
             if (cm.authrec != nullptr) {
                 cm.authrec->filter_group = fg;
                 cm.authrec->group_source = "pdef";
@@ -290,6 +341,9 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
         // [PROXYBASIC_DEBUG] Informando ausencia do usuario nas listas de grupos.
         proxy_basic_debug_log("%sUsuario nao localizado em listas de grupos para plugin '%s'", thread_id.c_str(),
                               pluginName.toCharArray());
+        // [GROUPTRACE_DEBUG] Falha ao localizar grupo sem padrao configurado.
+        group_trace_debug_log("Plugin '%s' nao encontrou grupo para '%s' e nao ha padrao configurado (entrada %d, funcao='%s', arquivo='%s')",
+                              pluginName.toCharArray(), user.c_str(), story_entry, function_label, file_label);
         return E2AUTH_NOGROUP;
     }
 
@@ -299,6 +353,9 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     fg = cm.filtergroup;
     // [PROXYBASIC_DEBUG] Registrando grupo atribuido ao usuario pelo plugin.
     proxy_basic_debug_log("%sUsuario associado ao grupo %d pelo plugin '%s'", thread_id.c_str(), fg, pluginName.toCharArray());
+    // [GROUPTRACE_DEBUG] Grupo encontrado com sucesso.
+    group_trace_debug_log("Plugin '%s' atribuiu grupo %d ao usuario '%s' (entrada %d, funcao='%s', arquivo='%s', fg_anterior=%d)",
+                          pluginName.toCharArray(), fg, user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     if (cm.authrec != nullptr) {
         cm.authrec->filter_group = fg;
         if (cm.authrec->user_name.length() == 0)

--- a/src/Auth.hpp
+++ b/src/Auth.hpp
@@ -132,6 +132,7 @@ bool extract_forwarded_user(HTTPHeader &h, std::string &username);
 
 // Debug helpers for proxy-basic tracing.
 void proxy_basic_debug_log(const char *fmt, ...);
+void group_trace_debug_log(const char *fmt, ...);
 
 class ProxyBasicDebugScope {
 public:

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -4637,10 +4637,23 @@ int ConnectionHandler::determineGroup(std::string &user, int &fg, StoryBoard &st
         return E2AUTH_NOMATCH;
     }
     cm.user = user;
+    std::string entry_function_name;
+    std::string entry_file_name;
+    unsigned int entry_index = story_entry >= 0 ? static_cast<unsigned int>(story_entry) : 0;
+    bool has_entry_info = story_entry >= 0 && story.getEntryDebugInfo(entry_index, entry_function_name, entry_file_name);
+    const char *function_label = (has_entry_info && !entry_function_name.empty()) ? entry_function_name.c_str() : "<desconhecido>";
+    const char *file_label = (has_entry_info && !entry_file_name.empty()) ? entry_file_name.c_str() : "<desconhecido>";
+    int fg_before_lookup = fg;
+    // [GROUPTRACE_DEBUG] Inicio da busca de grupo a partir do ConnectionHandler.
+    group_trace_debug_log("ConnectionHandler avaliara usuario '%s' usando entrada %d (funcao='%s', arquivo='%s', fg_atual=%d)",
+                          user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     if (!story.runFunctEntry(story_entry, cm)) {
 #ifdef E2DEBUG
         std::cerr << "User not in filter groups list for: icap " << std::endl;
 #endif
+        // [GROUPTRACE_DEBUG] Nenhum grupo encontrado pelo ConnectionHandler.
+        group_trace_debug_log("ConnectionHandler nao encontrou grupo para '%s' (entrada %d, funcao='%s', arquivo='%s')",
+                              user.c_str(), story_entry, function_label, file_label);
         return E2AUTH_NOGROUP;
     }
 
@@ -4648,5 +4661,8 @@ int ConnectionHandler::determineGroup(std::string &user, int &fg, StoryBoard &st
     std::cerr << "Group found for: " << user.c_str() << " in icap " << std::endl;
 #endif
     fg = cm.filtergroup;
+    // [GROUPTRACE_DEBUG] Grupo atribuido com sucesso no ConnectionHandler.
+    group_trace_debug_log("ConnectionHandler atribuiu grupo %d ao usuario '%s' (entrada %d, funcao='%s', arquivo='%s', fg_anterior=%d)",
+                          fg, user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     return E2AUTH_OK;
 }

--- a/src/SBFunction.cpp
+++ b/src/SBFunction.cpp
@@ -200,13 +200,13 @@ unsigned int SBFunction::getBIFunctID(String &action)  {    // get built-in func
     return 0;
 }
 
-String SBFunction::getState(unsigned int id) {     // get condition statement from state_id
+String SBFunction::getState(unsigned int id) const {     // get condition statement from state_id
     if (--id < SB_STATE_MAP_SIZE)
         return state_map[id];
     return "";
 };
 
-String SBFunction::getBIFunct(unsigned int &id) {    // get built-in function (action) from funct_id
+String SBFunction::getBIFunct(unsigned int &id) const {    // get built-in function (action) from funct_id
     if (id > 5000) {
         unsigned int i = id - 5001;
         if (i < SB_FUNC_MAP_SIZE)
@@ -215,6 +215,14 @@ String SBFunction::getBIFunct(unsigned int &id) {    // get built-in function (a
     return "";
 };
 
-String SBFunction::getName() {
+String SBFunction::getName() const {
     return name;
+}
+
+unsigned int SBFunction::getId() const {
+    return fn_id;
+}
+
+String SBFunction::getFileName() const {
+    return file_name;
 }

--- a/src/SBFunction.hpp
+++ b/src/SBFunction.hpp
@@ -211,9 +211,11 @@ class SBFunction
 	bool addline(String command, String params, String action, unsigned int line_no);
 	unsigned int getStateID(String & state);
     unsigned int getBIFunctID(String & action);
-    String getState(unsigned int id);
-	String getBIFunct(unsigned int &id);
-	String getName();
+    String getState(unsigned int id) const;
+    String getBIFunct(unsigned int &id) const;
+    String getName() const;
+    unsigned int getId() const;
+    String getFileName() const;
 
 
 };

--- a/src/StoryBoard.cpp
+++ b/src/StoryBoard.cpp
@@ -13,6 +13,7 @@
 #include <syslog.h>
 #include <algorithm>
 #include <netdb.h> // for gethostby
+#include <string>
 #include "ListContainer.hpp"
 #include "StoryBoard.hpp"
 #include "OptionContainer.hpp"
@@ -1027,6 +1028,37 @@ bool StoryBoard::runFunctEntry(unsigned int index, NaughtyFilter &cm) {
     else
         return false;
 };
+
+bool StoryBoard::getEntryDebugInfo(unsigned int index, std::string &function_name, std::string &file_name) const {
+    function_name.clear();
+    file_name.clear();
+
+    constexpr unsigned int entry_count = sizeof(entrys) / sizeof(entrys[0]);
+    if (index >= entry_count)
+        return false;
+
+    unsigned int entry_id = entrys[index];
+    if (entry_id == 0)
+        return false;
+
+    for (const auto &function : funct_vec) {
+        if (function.getId() == entry_id) {
+            function_name = function.getName().toCharArray();
+            String source_file = function.getFileName();
+            file_name = source_file.toCharArray();
+            return true;
+        }
+    }
+
+    if (entry_id > SB_BI_FUNC_BASE && !funct_vec.empty()) {
+        unsigned int temp_id = entry_id;
+        String builtin = funct_vec.front().getBIFunct(temp_id);
+        function_name = builtin.toCharArray();
+        return true;
+    }
+
+    return false;
+}
 
 std::deque<url_rec> StoryBoard::deep_urls(String &urld, NaughtyFilter &cm) {
     std::deque<url_rec> temp;

--- a/src/StoryBoard.hpp
+++ b/src/StoryBoard.hpp
@@ -78,6 +78,7 @@ class StoryBoard
     //bool runFunctEntry1(NaughtyFilter &cm);
     //bool runFunctEntry2(NaughtyFilter &cm);
     bool runFunctEntry(unsigned int index,  NaughtyFilter &cm);
+    bool getEntryDebugInfo(unsigned int index, std::string &function_name, std::string &file_name) const;
     bool setEntry(unsigned int index, String fname);
     //bool setEntry1(String fname);
     //bool setEntry2(String fname);


### PR DESCRIPTION
## Summary
- share a common /var/log/e2guardian/debug.log writer for proxy and group debug tracing
- record GROUPTRACE_DEBUG entries to the debug log file instead of syslog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f66edb4cf8832eb9b17a1518992015