### PR TITLE
Ensure auth plugin map defaults and install directories

### DIFF
--- a/configs/Makefile.am
+++ b/configs/Makefile.am
@@ -21,13 +21,14 @@ EXTRA_DIST = e2guardian.conf.in e2guardianf1.conf.in examplef1.story.in
 
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR); \
+	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR)/lists; \
+	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR)/lists/authplugins; \
 	for l in $(FLISTS) ; do \
 	echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample"; \
 	$(INSTALL_DATA) $$l $(DESTDIR)$(E2CONFDIR)/$$l.sample; \
 	done
 
 install-data-hook:
-	$(MKDIR_P) $(DESTDIR)$(E2CONFDIR)/lists/authplugins; \
 	for l in $(AUTHPLUGIN_LISTS) ; do \
 	base=`basename $$l`; \
 	src="$(srcdir)/$$l"; \

--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -432,17 +432,18 @@ ipsitelist = 'name=nomitm,path=__LISTDIR__/nomitmsiteiplist'
 
 
 ## Auth mapping files - Map users (or client IPs) to filter groups
-## Note that from v5.4 lists used by auth plugins are defined here and 
-## not in auth *.conf files
+## Note that from v5.4 lists used by auth plugins are defined here and
+## not in auth *.conf files.  LISTDIR defaults to lists/common, so the
+## auth maps live one level up inside lists/authplugins.
 
 # Generic user to group mapping - used by default by basic, digest, ntlm, 
 # ident & icap plugins
-maplist = 'name=defaultusermap, path=__LISTDIR__/authplugins/filtergroupslist'
+maplist = 'name=defaultusermap, path=__LISTDIR__/../authplugins/filtergroupslist'
 # for ip auth
-ipmaplist = 'name=ipmap, path=__LISTDIR__/authplugins/ipgroups'
+ipmaplist = 'name=ipmap, path=__LISTDIR__/../authplugins/ipgroups'
 
 # for port auth
-maplist = 'name=portmap, path=__LISTDIR__/authplugins/portgroups'
+maplist = 'name=portmap, path=__LISTDIR__/../authplugins/portgroups'
 
 
 # If on a user without group is considered like unauthenfied

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -1005,6 +1005,62 @@ bool OptionContainer::read(std::string &filename, int type) {
         maplist_dq = findoptionM("maplist");
         ipmaplist_dq = findoptionM("ipmaplist");
 
+        // Ensure that default authentication maps are available even when
+        // older configuration files are missing the maplist directives.  The
+        // runtime expects these files to live under
+        // __CONFDIR__/lists/authplugins/ so we synthesise sensible defaults
+        // when they are not provided explicitly.
+        String authplugins_dir = __CONFDIR;
+        authplugins_dir += "/lists/authplugins";
+
+        bool has_defaultusermap = false;
+        bool has_portmap = false;
+        for (const auto &entry : maplist_dq) {
+            if (entry.contains("name=defaultusermap")) {
+                has_defaultusermap = true;
+            } else if (entry.contains("name=portmap")) {
+                has_portmap = true;
+            }
+            if (has_defaultusermap && has_portmap) {
+                break;
+            }
+        }
+
+        if (!has_defaultusermap) {
+            String entry = "name=defaultusermap,path=";
+            entry += authplugins_dir;
+            entry += "/filtergroupslist";
+            entry += ",listdir=";
+            entry += authplugins_dir;
+            maplist_dq.push_back(entry);
+        }
+
+        if (!has_portmap) {
+            String entry = "name=portmap,path=";
+            entry += authplugins_dir;
+            entry += "/portgroups";
+            entry += ",listdir=";
+            entry += authplugins_dir;
+            maplist_dq.push_back(entry);
+        }
+
+        bool has_ipmap = false;
+        for (const auto &entry : ipmaplist_dq) {
+            if (entry.contains("name=ipmap")) {
+                has_ipmap = true;
+                break;
+            }
+        }
+
+        if (!has_ipmap) {
+            String entry = "name=ipmap,path=";
+            entry += authplugins_dir;
+            entry += "/ipgroups";
+            entry += ",listdir=";
+            entry += authplugins_dir;
+            ipmaplist_dq.push_back(entry);
+        }
+
         if ((findoptionS("authrequiresuserande2roup") == "on") && (authplugins.size() > 1))
             auth_requires_user_and_group = true;
 


### PR DESCRIPTION
## Summary
- make sure the installer always creates the lists/authplugins directory tree before copying configuration samples
- update the sample configuration so maplist directives resolve to lists/authplugins relative to LISTDIR
- add runtime fallbacks that synthesise the default map, port, and IP maps when older configs omit them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f67642b874832e9bcef2c1172de8b9