### PR TITLE
Remover logs de debug do proxy basic

### DIFF
--- a/src/Auth.cpp
+++ b/src/Auth.cpp
@@ -18,17 +18,8 @@
 #include <syslog.h>
 #include <algorithm>
 #include <cctype>
-#include <cstdarg>
-#include <cstdio>
 #include <sstream>
-#include <vector>
 #include <arpa/inet.h>
-#include <cerrno>
-#include <cstring>
-#include <fcntl.h>
-#include <mutex>
-#include <sys/stat.h>
-#include <unistd.h>
 
 // GLOBALS
 
@@ -82,117 +73,8 @@ bool is_likely_ip(const std::string &token)
 }
 }
 
-namespace
-{
-constexpr const char *kDebugLogPath = "/var/log/e2guardian/debug.log";
-std::mutex debug_log_mutex;
-int debug_log_fd = -1;
-
-void append_debug_log(const std::string &message)
-{
-    std::lock_guard<std::mutex> lock(debug_log_mutex);
-    if (debug_log_fd == -1) {
-        debug_log_fd = open(kDebugLogPath, O_WRONLY | O_CREAT | O_APPEND, 0640);
-        if (debug_log_fd == -1) {
-            syslog(LOG_ERR, "%sUnable to open %s for debug logging: %s", thread_id.c_str(), kDebugLogPath, strerror(errno));
-            return;
-        }
-    }
-
-    ssize_t ignored = write(debug_log_fd, message.c_str(), message.size());
-    (void)ignored;
-}
-}
-
-thread_local bool proxy_basic_debug_scope_flag = false;
-
-// [PROXYBASIC_DEBUG] Escreve mensagens de rastreamento no arquivo dedicado.
-void proxy_basic_debug_log(const char *fmt, ...)
-{
-    if (!proxy_basic_debug_scope_flag)
-        return;
-
-    char stack_buffer[1024];
-    va_list args;
-    va_start(args, fmt);
-    va_list args_copy;
-    va_copy(args_copy, args);
-    int needed = vsnprintf(stack_buffer, sizeof(stack_buffer), fmt, args_copy);
-    va_end(args_copy);
-
-    std::string message;
-    if (needed < 0) {
-        message = "Falha ao formatar mensagem de debug";
-    } else if (static_cast<size_t>(needed) < sizeof(stack_buffer)) {
-        message.assign(stack_buffer, static_cast<size_t>(needed));
-    } else {
-        std::vector<char> dynamic_buffer(static_cast<size_t>(needed) + 1, '\0');
-        va_list args_retry;
-        va_copy(args_retry, args);
-        vsnprintf(dynamic_buffer.data(), dynamic_buffer.size(), fmt, args_retry);
-        va_end(args_retry);
-        message.assign(dynamic_buffer.data());
-    }
-    va_end(args);
-
-    std::string formatted = "[PROXYBASIC_DEBUG] ";
-    formatted += message;
-    formatted.push_back('\n');
-
-    append_debug_log(formatted);
-}
-
-// [GROUPTRACE_DEBUG] Emite mensagens de rastreamento sobre atribuicao de grupos.
-void group_trace_debug_log(const char *fmt, ...)
-{
-    char stack_buffer[1024];
-    va_list args;
-    va_start(args, fmt);
-    va_list args_copy;
-    va_copy(args_copy, args);
-    int needed = vsnprintf(stack_buffer, sizeof(stack_buffer), fmt, args_copy);
-    va_end(args_copy);
-
-    std::string message;
-    if (needed < 0) {
-        message = "Falha ao formatar mensagem de rastreamento de grupos";
-    } else if (static_cast<size_t>(needed) < sizeof(stack_buffer)) {
-        message.assign(stack_buffer, static_cast<size_t>(needed));
-    } else {
-        std::vector<char> dynamic_buffer(static_cast<size_t>(needed) + 1, '\0');
-        va_list args_retry;
-        va_copy(args_retry, args);
-        vsnprintf(dynamic_buffer.data(), dynamic_buffer.size(), fmt, args_retry);
-        va_end(args_retry);
-        message.assign(dynamic_buffer.data());
-    }
-    va_end(args);
-
-    std::string tagged_message = std::string("[GROUPTRACE_DEBUG] ") + message;
-    std::string formatted = thread_id + tagged_message + '\n';
-    if (!is_daemonised) {
-        std::cerr << formatted << std::flush;
-    }
-    append_debug_log(formatted);
-}
-
-ProxyBasicDebugScope::ProxyBasicDebugScope(bool enable)
-    : previous_(proxy_basic_debug_scope_flag)
-{
-    if (enable)
-        proxy_basic_debug_scope_flag = true;
-}
-
-ProxyBasicDebugScope::~ProxyBasicDebugScope()
-{
-    proxy_basic_debug_scope_flag = previous_;
-}
-
 std::string normalise_auth_username(const std::string &raw)
 {
-    // [PROXYBASIC_DEBUG] Registrando recebimento do usuario bruto para normalizacao.
-    proxy_basic_debug_log("%sRecebido usuario bruto para normalizacao: '%s'", thread_id.c_str(), raw.c_str());
-
     std::string result = trim_copy(raw);
     if (result.empty())
         return result;
@@ -211,21 +93,13 @@ std::string normalise_auth_username(const std::string &raw)
 
     result = trim_copy(result);
 
-    // [PROXYBASIC_DEBUG] Registrando resultado da normalizacao antes de alterar caixa.
-    proxy_basic_debug_log("%sUsuario apos normalizacao sem alterar caixa: '%s'", thread_id.c_str(), result.c_str());
-
     return result;
 }
 
 bool extract_forwarded_user(HTTPHeader &h, std::string &username)
 {
     std::string forwarded = h.getXForwardedForIP();
-    // [PROXYBASIC_DEBUG] Registrando conteudo bruto do cabecalho X-Forwarded-For.
-    proxy_basic_debug_log("%sCabecalho X-Forwarded-For bruto: '%s'", thread_id.c_str(), forwarded.c_str());
-
     if (forwarded.empty()) {
-        // [PROXYBASIC_DEBUG] Avisando ausencia do cabecalho X-Forwarded-For.
-        proxy_basic_debug_log("%sCabecalho X-Forwarded-For ausente ou vazio", thread_id.c_str());
         return false;
     }
 
@@ -234,27 +108,19 @@ bool extract_forwarded_user(HTTPHeader &h, std::string &username)
     std::string candidate;
     while (std::getline(stream, token, ',')) {
         std::string trimmed = trim_copy(token);
-        // [PROXYBASIC_DEBUG] Rastreamento de cada token analisado no X-Forwarded-For.
-        proxy_basic_debug_log("%sToken X-Forwarded-For analisado: '%s'", thread_id.c_str(), trimmed.c_str());
         if (!trimmed.empty())
             candidate = trimmed;
     }
 
     if (candidate.empty()) {
-        // [PROXYBASIC_DEBUG] Informando que nao foi encontrado token valido no cabecalho.
-        proxy_basic_debug_log("%sNenhum candidato encontrado no cabecalho X-Forwarded-For", thread_id.c_str());
         return false;
     }
 
     if (is_likely_ip(candidate)) {
-        // [PROXYBASIC_DEBUG] Indicando que o token final parece endereco IP e sera ignorado.
-        proxy_basic_debug_log("%sUltimo token do X-Forwarded-For parece um IP ('%s'), ignorando", thread_id.c_str(), candidate.c_str());
         return false;
     }
 
     username = candidate;
-    // [PROXYBASIC_DEBUG] Informando usuario obtido do X-Forwarded-For.
-    proxy_basic_debug_log("%sUsuario extraido do X-Forwarded-For: '%s'", thread_id.c_str(), username.c_str());
     return true;
 }
 
@@ -287,12 +153,7 @@ String AuthPlugin::getPluginName()
 // return -1 when user not found
 int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, NaughtyFilter &cm )
 {
-    // [PROXYBASIC_DEBUG] Iniciando determinacao de grupo para o usuario informado.
-    proxy_basic_debug_log("%sInicio determineGroup para plugin '%s' com usuario bruto '%s'", thread_id.c_str(),
-                          pluginName.toCharArray(), user.c_str());
     if (user.length() < 1 || user == "-") {
-        // [PROXYBASIC_DEBUG] Indicando usuario invalido recebido.
-        proxy_basic_debug_log("%sUsuario invalido para determineGroup (vazio ou '-')", thread_id.c_str());
         return E2AUTH_NOMATCH;
     }
     user = normalise_auth_username(user);
@@ -300,8 +161,6 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     String lastcategory;
     u.toLower(); // since the filtergroupslist is read in in lowercase, we should do this.
     user = u.toCharArray(); // also pass back to ConnectionHandler, so appears lowercase in logs
-    // [PROXYBASIC_DEBUG] Registrando usuario apos conversao para minusculas.
-    proxy_basic_debug_log("%sUsuario apos conversao para minusculas: '%s'", thread_id.c_str(), user.c_str());
     std::string entry_function_name;
     std::string entry_file_name;
     unsigned int entry_index = story_entry >= 0 ? static_cast<unsigned int>(story_entry) : 0;
@@ -309,9 +168,6 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     const char *function_label = (has_entry_info && !entry_function_name.empty()) ? entry_function_name.c_str() : "<desconhecido>";
     const char *file_label = (has_entry_info && !entry_file_name.empty()) ? entry_file_name.c_str() : "<desconhecido>";
     int fg_before_lookup = fg;
-    // [GROUPTRACE_DEBUG] Inicio do rastreamento da determinacao de grupo.
-    group_trace_debug_log("Plugin '%s' avaliara usuario '%s' usando entrada %d (funcao='%s', arquivo='%s', fg_atual=%d)",
-                         pluginName.toCharArray(), user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     //  String ue(u);
     //  ue += "=";
 
@@ -322,11 +178,6 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
         int t = get_default(!cm.request_header->isProxyRequest);
         if (t > 0) {
             fg = --t;
-            // [PROXYBASIC_DEBUG] Indicando aplicacao do grupo padrao por falta de correspondencia.
-            proxy_basic_debug_log("%sUsuario nao encontrado; aplicando grupo padrao %d", thread_id.c_str(), fg);
-            // [GROUPTRACE_DEBUG] Nenhuma correspondencia encontrada; aplicando grupo padrao.
-            group_trace_debug_log("Plugin '%s' nao encontrou grupo para '%s' (entrada %d, funcao='%s', arquivo='%s'); usando padrao=%d",
-                                  pluginName.toCharArray(), user.c_str(), story_entry, function_label, file_label, fg);
             if (cm.authrec != nullptr) {
                 cm.authrec->filter_group = fg;
                 cm.authrec->group_source = "pdef";
@@ -338,12 +189,6 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
 #ifdef E2DEBUG
         std::cerr << "User not in filter groups list for: " << pluginName.c_str() << std::endl;
 #endif
-        // [PROXYBASIC_DEBUG] Informando ausencia do usuario nas listas de grupos.
-        proxy_basic_debug_log("%sUsuario nao localizado em listas de grupos para plugin '%s'", thread_id.c_str(),
-                              pluginName.toCharArray());
-        // [GROUPTRACE_DEBUG] Falha ao localizar grupo sem padrao configurado.
-        group_trace_debug_log("Plugin '%s' nao encontrou grupo para '%s' e nao ha padrao configurado (entrada %d, funcao='%s', arquivo='%s')",
-                              pluginName.toCharArray(), user.c_str(), story_entry, function_label, file_label);
         return E2AUTH_NOGROUP;
     }
 
@@ -351,11 +196,6 @@ int AuthPlugin::determineGroup(std::string &user, int &fg, StoryBoard & story, N
     std::cerr << "Group found for: " << user.c_str() << " in " << pluginName.c_str() << std::endl;
 #endif
     fg = cm.filtergroup;
-    // [PROXYBASIC_DEBUG] Registrando grupo atribuido ao usuario pelo plugin.
-    proxy_basic_debug_log("%sUsuario associado ao grupo %d pelo plugin '%s'", thread_id.c_str(), fg, pluginName.toCharArray());
-    // [GROUPTRACE_DEBUG] Grupo encontrado com sucesso.
-    group_trace_debug_log("Plugin '%s' atribuiu grupo %d ao usuario '%s' (entrada %d, funcao='%s', arquivo='%s', fg_anterior=%d)",
-                          pluginName.toCharArray(), fg, user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     if (cm.authrec != nullptr) {
         cm.authrec->filter_group = fg;
         if (cm.authrec->user_name.length() == 0)

--- a/src/Auth.hpp
+++ b/src/Auth.hpp
@@ -130,17 +130,4 @@ std::string normalise_auth_username(const std::string &raw);
 // upstream proxy adds it as the last comma-separated value.
 bool extract_forwarded_user(HTTPHeader &h, std::string &username);
 
-// Debug helpers for proxy-basic tracing.
-void proxy_basic_debug_log(const char *fmt, ...);
-void group_trace_debug_log(const char *fmt, ...);
-
-class ProxyBasicDebugScope {
-public:
-    explicit ProxyBasicDebugScope(bool enable);
-    ~ProxyBasicDebugScope();
-
-private:
-    bool previous_;
-};
-
 #endif

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -60,32 +60,6 @@ extern std::atomic<bool> ttg;
 extern thread_local std::string thread_id;
 
 
-namespace {
-
-bool has_proxy_basic_plugin()
-{
-    for (auto it = o.authplugins_begin; it != o.authplugins_end; ++it) {
-        AuthPlugin *plugin = static_cast<AuthPlugin *>(*it);
-        if (plugin == nullptr)
-            continue;
-        String name = plugin->getPluginName();
-        if (name.startsWith("proxy-basic"))
-            return true;
-    }
-    return false;
-}
-
-bool is_proxy_basic_plugin(AuthPlugin *plugin)
-{
-    if (plugin == nullptr)
-        return false;
-    String name = plugin->getPluginName();
-    return name.startsWith("proxy-basic");
-}
-
-}
-
-
 // IMPLEMENTATION
 
 ConnectionHandler::ConnectionHandler()
@@ -529,18 +503,12 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
 
     sock.setTimeout(o.connect_timeout);
 
-    // [PROXYBASIC_DEBUG] Registrando tentativa inicial de conexao com o destino solicitado.
-    proxy_basic_debug_log("%sTentando conectar ao destino %s:%d (isdirect=%d)", thread_id.c_str(),
-                          cm.connect_site.toCharArray(), port, cm.isdirect);
 
     while (++retry < o.connect_retries) {
         lerr_mess = 0;
         if (retry > 0) {
             if (o.logconerror)
                 syslog(LOG_INFO, "%s retry %d to connect to %s", thread_id.c_str(), retry, cm.urldomain.c_str());
-            // [PROXYBASIC_DEBUG] Indicando nova tentativa de conexao apos falha anterior.
-            proxy_basic_debug_log("%sRe-tentativa %d para conectar ao destino %s:%d", thread_id.c_str(), retry,
-                                  cm.connect_site.toCharArray(), port);
             if (!sock.isTimedout())
                 usleep(1000);       // don't hammer upstream
         }
@@ -571,18 +539,11 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
 #ifdef E2DEBUG
                 std::cerr << thread_id << "Connecting to IP " << des_ip << " port " << port << std::endl;
 #endif
-                // [PROXYBASIC_DEBUG] Registrando conexao direta usando IP conhecido.
-                proxy_basic_debug_log("%sConectando diretamente para %s:%d", thread_id.c_str(), des_ip.toCharArray(), port);
                 int rc = sock.connect(des_ip, port);
                 if (rc < 0) {
                     lerr_mess = 203;
-                    // [PROXYBASIC_DEBUG] Avisando falha ao conectar diretamente ao destino.
-                    proxy_basic_debug_log("%sFalha ao conectar diretamente para %s:%d (rc=%d)", thread_id.c_str(),
-                                          des_ip.toCharArray(), port, rc);
                     continue;
                 }
-                // [PROXYBASIC_DEBUG] Informando sucesso na conexao direta ao destino.
-                proxy_basic_debug_log("%sConexao direta estabelecida com %s:%d", thread_id.c_str(), des_ip.toCharArray(), port);
                 return rc;
             } else {
                 //dns lookup
@@ -648,20 +609,14 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
                     std::cerr << thread_id << "Connecting to IP " << t << " port " <<
                     port << " after dns lookup" << std::endl;
 #endif
-                    // [PROXYBASIC_DEBUG] Registrando tentativa de conexao apos resolucao DNS.
-                    proxy_basic_debug_log("%sConectando para %s:%d apos DNS", thread_id.c_str(), t, port);
                     int rc = sock.connect(t, port);
                     if (rc == 0) {
                         freeaddrinfo(infoptr);
 #ifdef E2DEBUG
                         std::cerr << thread_id << "Got connection upfailure is " << cm.upfailure << std::endl;
 #endif
-                        // [PROXYBASIC_DEBUG] Informando que a conexao apos DNS foi estabelecida com sucesso.
-                        proxy_basic_debug_log("%sConexao estabelecida apos DNS para %s:%d", thread_id.c_str(), t, port);
                         return 0;
                     }
-                    // [PROXYBASIC_DEBUG] Avisando falha na conexao apos resolucao DNS.
-                    proxy_basic_debug_log("%sFalha ao conectar apos DNS para %s:%d (rc=%d)", thread_id.c_str(), t, port, rc);
                 }
                 freeaddrinfo(infoptr);
                 if (may_be_loop) break;
@@ -670,21 +625,15 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
             }
         } else {  //is via proxy
             sock.setTimeout(o.proxy_timeout);
-            // [PROXYBASIC_DEBUG] Registrando tentativa de conexao ao proxy pai configurado.
-            proxy_basic_debug_log("%sConectando ao proxy pai %s:%d", thread_id.c_str(), o.proxy_ip.c_str(), o.proxy_port);
             int rc = sock.connect(o.proxy_ip, o.proxy_port);
             if (rc < 0) {
                 if (sock.isTimedout())
                     lerr_mess = 201;
                 else
                     lerr_mess = 202;
-                // [PROXYBASIC_DEBUG] Avisando falha ao conectar ao proxy pai.
-                proxy_basic_debug_log("%sFalha ao conectar ao proxy pai %s:%d (rc=%d)", thread_id.c_str(),
                                       o.proxy_ip.c_str(), o.proxy_port, rc);
                 continue;
             }
-            // [PROXYBASIC_DEBUG] Informando que a conexao com o proxy pai foi estabelecida.
-            proxy_basic_debug_log("%sConexao estabelecida com proxy pai %s:%d", thread_id.c_str(), o.proxy_ip.c_str(),
                                   o.proxy_port);
             return rc;
         }
@@ -701,9 +650,6 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
     cm.blocktype = 3;
     cm.isexception = false;
     cm.isbypass = false;
-    // [PROXYBASIC_DEBUG] Registrando falha geral apos esgotar tentativas de conexao.
-    proxy_basic_debug_log("%sTodas as tentativas de saida falharam para %s:%d (codigo %d)", thread_id.c_str(),
-                          cm.connect_site.toCharArray(), port, lerr_mess);
     return -1;
 }
 
@@ -749,8 +695,6 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
     struct timeval thestart;
     gettimeofday(&thestart, NULL);
 
-    ProxyBasicDebugScope proxy_basic_scope(has_proxy_basic_plugin());
-
     //peerconn.setTimeout(o.proxy_timeout);
     peerconn.setTimeout(o.pcon_timeout);
 
@@ -773,9 +717,6 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
     std::deque<CSPlugin *> responsescanners;
 
     std::string clientip(ip.toCharArray()); // hold the clients ip
-    // [PROXYBASIC_DEBUG] Registrando chegada de nova conexao oriunda do cache-peer.
-    proxy_basic_debug_log("%sRecebida nova conexao do cache-peer %s (ismitm=%d)", thread_id.c_str(),
-                          clientip.c_str(), ismitm ? 1 : 0);
     header.setClientIP(ip);
 
     if (clienthost) delete clienthost;
@@ -849,8 +790,6 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
             persistPeer = false;
         } else {
             ++dystat->reqs;
-            // [PROXYBASIC_DEBUG] Confirmando leitura do cabecalho HTTP da conexao.
-            proxy_basic_debug_log("%sCabecalho HTTP recebido da conexao do cache-peer", thread_id.c_str());
         }
         //
         // End of set-up section
@@ -929,16 +868,6 @@ int ConnectionHandler::handleConnection(Socket &peerconn, String &ip, bool ismit
 //
             // do this normalisation etc just the once at the start.
             checkme.setURL(ismitm);
-            String request_method(header.requestType());
-            // [PROXYBASIC_DEBUG] Resumindo metodo, URL e modo da requisicao recebida.
-            proxy_basic_debug_log("%sResumo da requisicao: metodo='%s' url='%s' proxy=%d", thread_id.c_str(),
-                                  request_method.toCharArray(), checkme.url.c_str(), header.isProxyRequest);
-            // [PROXYBASIC_DEBUG] Registrando credenciais brutas vindas do Proxy-Authorization.
-            proxy_basic_debug_log("%sCabecalho Proxy-Authorization bruto: '%s'", thread_id.c_str(),
-                                  header.getRawAuthData().c_str());
-            // [PROXYBASIC_DEBUG] Registrando informacoes recebidas no cabecalho X-Forwarded-For.
-            proxy_basic_debug_log("%sCabecalho X-Forwarded-For recebido: '%s'", thread_id.c_str(),
-                                  header.getXForwardedForIP().c_str());
 
             if(o.log_requests) {
                 std::string fnt;
@@ -3041,10 +2970,6 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
             // Logic changed to allow auth scan with multiple ports as option to auth-port
             //       fixed mapping
             //
-            bool plugin_is_proxy_basic = is_proxy_basic_plugin(auth_plugin);
-            if (plugin_is_proxy_basic)
-                // [PROXYBASIC_DEBUG] Indicando que o plugin proxy-basic sera consultado para credenciais.
-                proxy_basic_debug_log("%sConsultando plugin proxy-basic para identificar usuario", thread_id.c_str());
 
             if (o.map_auth_to_ports) {
                 if (o.filter_ports.size() > 1) {
@@ -3065,9 +2990,6 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
             }
 
             if (rc == E2AUTH_NOMATCH) {
-                if (plugin_is_proxy_basic)
-                    // [PROXYBASIC_DEBUG] Informando que nao foram encontradas credenciais nesta rodada.
-                    proxy_basic_debug_log("%sPlugin proxy-basic nao encontrou credenciais nesta tentativa", thread_id.c_str());
 #ifdef E2DEBUG
                 std::cerr << "Auth plugin did not find a match; querying remaining plugins" << std::endl;
 #endif
@@ -3094,34 +3016,20 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
                 std::cerr << "Auth plugin  returned OK but no persist not setting persist auth" << std::endl;
 #endif
                 overide_persist = true;
-                if (plugin_is_proxy_basic)
-                    // [PROXYBASIC_DEBUG] Indicando autenticacao sem persistencia retornada pelo plugin.
-                    proxy_basic_debug_log("%sPlugin proxy-basic autenticou sem persistencia", thread_id.c_str());
             } else if (rc < 0) {
                 if (!is_daemonised)
                     std::cerr << thread_id << "Auth plugin returned error code: " << rc << std::endl;
                 syslog(LOG_ERR, "%sAuth plugin returned error code: %d", thread_id.c_str(), rc);
-                if (plugin_is_proxy_basic)
-                    // [PROXYBASIC_DEBUG] Registrando codigo de erro devolvido pelo plugin.
-                    proxy_basic_debug_log("%sPlugin proxy-basic retornou erro %d", thread_id.c_str(), rc);
                 dobreak = true;
                 break;
             }
 #ifdef E2DEBUG
             std::cerr << thread_id << " -Auth plugin found username " << clientuser << " (" << oldclientuser << "), now determining group" << std::endl;
 #endif
-            if (plugin_is_proxy_basic)
-                // [PROXYBASIC_DEBUG] Informando usuario retornado e inicio da determinacao de grupo.
-                proxy_basic_debug_log("%sPlugin proxy-basic retornou usuario '%s' (anterior '%s'); iniciando determineGroup",
-                                      thread_id.c_str(), clientuser.c_str(), oldclientuser.c_str());
             if (clientuser == oldclientuser) {
 #ifdef E2DEBUG
                 std::cerr << thread_id << " -Same user as last time, re-using old group no." << std::endl;
 #endif
-                if (plugin_is_proxy_basic)
-                    // [PROXYBASIC_DEBUG] Informando reaproveitamento do grupo anterior.
-                    proxy_basic_debug_log("%sPlugin proxy-basic indicou mesmo usuario anterior; reutilizando grupo %d",
-                                          thread_id.c_str(), oldfg);
                 authed = true;
                 filtergroup = oldfg;
                 break;
@@ -3132,10 +3040,6 @@ bool ConnectionHandler::doAuth(int &rc, bool &authed, int &filtergroup, AuthPlug
 #ifdef E2DEBUG
                 std::cerr << thread_id << "Auth plugin found username & group; not querying remaining plugins" << std::endl;
 #endif
-                if (plugin_is_proxy_basic)
-                    // [PROXYBASIC_DEBUG] Registrando associacao de grupo devolvida pelo plugin.
-                    proxy_basic_debug_log("%sPlugin proxy-basic associou usuario '%s' ao grupo %d", thread_id.c_str(),
-                                          clientuser.c_str(), filtergroup);
                 authed = true;
                 break;
             } else if (rc == E2AUTH_NOMATCH) {
@@ -4644,15 +4548,11 @@ int ConnectionHandler::determineGroup(std::string &user, int &fg, StoryBoard &st
     const char *function_label = (has_entry_info && !entry_function_name.empty()) ? entry_function_name.c_str() : "<desconhecido>";
     const char *file_label = (has_entry_info && !entry_file_name.empty()) ? entry_file_name.c_str() : "<desconhecido>";
     int fg_before_lookup = fg;
-    // [GROUPTRACE_DEBUG] Inicio da busca de grupo a partir do ConnectionHandler.
-    group_trace_debug_log("ConnectionHandler avaliara usuario '%s' usando entrada %d (funcao='%s', arquivo='%s', fg_atual=%d)",
                           user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     if (!story.runFunctEntry(story_entry, cm)) {
 #ifdef E2DEBUG
         std::cerr << "User not in filter groups list for: icap " << std::endl;
 #endif
-        // [GROUPTRACE_DEBUG] Nenhum grupo encontrado pelo ConnectionHandler.
-        group_trace_debug_log("ConnectionHandler nao encontrou grupo para '%s' (entrada %d, funcao='%s', arquivo='%s')",
                               user.c_str(), story_entry, function_label, file_label);
         return E2AUTH_NOGROUP;
     }
@@ -4661,8 +4561,6 @@ int ConnectionHandler::determineGroup(std::string &user, int &fg, StoryBoard &st
     std::cerr << "Group found for: " << user.c_str() << " in icap " << std::endl;
 #endif
     fg = cm.filtergroup;
-    // [GROUPTRACE_DEBUG] Grupo atribuido com sucesso no ConnectionHandler.
-    group_trace_debug_log("ConnectionHandler atribuiu grupo %d ao usuario '%s' (entrada %d, funcao='%s', arquivo='%s', fg_anterior=%d)",
                           fg, user.c_str(), story_entry, function_label, file_label, fg_before_lookup);
     return E2AUTH_OK;
 }

--- a/src/authplugins/ProxyFirstBasic.cpp
+++ b/src/authplugins/ProxyFirstBasic.cpp
@@ -57,43 +57,30 @@ int pf_basic_instance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h
 {
     // don't match for non-basic auth types
     String raw_type(h.getAuthType());
-    // [PROXYBASIC_DEBUG] Informando inicio do processamento identify do proxy-basic.
-    proxy_basic_debug_log("%sIniciando identify do proxy-basic: auth_type='%s' raw_auth='%s'", thread_id.c_str(),
-                          raw_type.toCharArray(), h.getRawAuthData().c_str());
 
     String t(raw_type);
     t.toLower();
     if (t == "basic") {
         // extract username
         string = h.getAuthData();
-        // [PROXYBASIC_DEBUG] Registrando credencial BASIC apos decodificacao.
-        proxy_basic_debug_log("%sCredencial BASIC decodificada: '%s'", thread_id.c_str(), string.c_str());
         if (string.length() > 0) {
             string.resize(string.find_first_of(':'));
             authrec.user_name = string;
             authrec.user_source = "pf_basic";
             is_real_user = true;
-            // [PROXYBASIC_DEBUG] Informando usuario obtido do cabecalho Proxy-Authorization.
-            proxy_basic_debug_log("%sUsuario obtido do cabecalho Proxy-Authorization: '%s'", thread_id.c_str(), string.c_str());
             return E2AUTH_OK;
         }
     }
 
-    // [PROXYBASIC_DEBUG] Indicando tentativa de extrair usuario do cabecalho X-Forwarded-For.
-    proxy_basic_debug_log("%sTentando extrair usuario do cabecalho X-Forwarded-For", thread_id.c_str());
     std::string forwarded_user;
     if (extract_forwarded_user(h, forwarded_user)) {
         string = forwarded_user;
         authrec.user_name = string;
         authrec.user_source = "forwarded";
         is_real_user = true;
-        // [PROXYBASIC_DEBUG] Informando usuario obtido do X-Forwarded-For.
-        proxy_basic_debug_log("%sUsuario obtido do X-Forwarded-For: '%s'", thread_id.c_str(), string.c_str());
         return E2AUTH_OK;
     }
 
-    // [PROXYBASIC_DEBUG] Registrando ausencia de credenciais validas apos todas as tentativas.
-    proxy_basic_debug_log("%sNenhuma credencial valida encontrada para proxy-basic", thread_id.c_str());
     return E2AUTH_NOMATCH;
 }
 
@@ -102,21 +89,14 @@ int pf_basic_instance::determineGroup(std::string &user, int &rfg, StoryBoard &s
     if (user.length() < 1 || user == "-")
         return E2AUTH_NOMATCH;
 
-    // [PROXYBASIC_DEBUG] Registrando usuario recebido para determinacao de grupo no plugin.
-    proxy_basic_debug_log("%sdetermineGroup (proxy-basic) recebeu usuario '%s'", thread_id.c_str(), user.c_str());
     std::string normalised = normalise_auth_username(user);
     if (normalised.empty())
         return E2AUTH_NOMATCH;
 
-    // [PROXYBASIC_DEBUG] Registrando resultado da normalizacao antes de converter para minusculas.
-    proxy_basic_debug_log("%sUsuario apos normalizacao (antes do lower-case): '%s'", thread_id.c_str(), normalised.c_str());
     String lowered(normalised.c_str());
     lowered.toLower();
     user = lowered.toCharArray();
 
-    // [PROXYBASIC_DEBUG] Informando usuario apos conversao para minusculas no determineGroup.
-    proxy_basic_debug_log("%sUsuario apos conversao para minusculas no determineGroup do proxy-basic: '%s'",
-                          thread_id.c_str(), user.c_str());
 
     cm.user = user;
 
@@ -125,8 +105,6 @@ int pf_basic_instance::determineGroup(std::string &user, int &rfg, StoryBoard &s
         if (default_group > 0) {
             rfg = default_group - 1;
             cm.filtergroup = rfg;
-            // [PROXYBASIC_DEBUG] Indicando aplicacao do grupo padrao devido a ausencia de correspondencia.
-            proxy_basic_debug_log("%sUsuario nao localizado; aplicando grupo padrao %d no proxy-basic", thread_id.c_str(), rfg);
             if (cm.authrec != nullptr) {
                 cm.authrec->group_source = cv["plugname"];
                 cm.authrec->filter_group = rfg;
@@ -138,14 +116,10 @@ int pf_basic_instance::determineGroup(std::string &user, int &rfg, StoryBoard &s
 #ifdef E2DEBUG
         std::cerr << thread_id << "User not in filter groups list for: " << cv["plugname"].c_str() << std::endl;
 #endif
-        // [PROXYBASIC_DEBUG] Informando que o usuario nao foi encontrado nas listas do plugin.
-        proxy_basic_debug_log("%sUsuario '%s' nao encontrado nas listas do proxy-basic", thread_id.c_str(), user.c_str());
         return E2AUTH_NOGROUP;
     }
 
     rfg = cm.filtergroup;
-    // [PROXYBASIC_DEBUG] Registrando grupo atribuido ao usuario pelo proxy-basic.
-    proxy_basic_debug_log("%sUsuario '%s' associado ao grupo %d pelo proxy-basic", thread_id.c_str(), user.c_str(), rfg);
     if (cm.authrec != nullptr) {
         cm.authrec->group_source = cv["plugname"];
         cm.authrec->filter_group = rfg;


### PR DESCRIPTION
## Summary
- remove as funções e declarações de logging especiais do proxy-basic
- limpa o plugin proxy-first-basic retirando chamadas de debug
- elimina rastreamento temporário no ConnectionHandler e auxiliares não utilizados

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f69d9edee8832e9493ef1bea7cb33f