### PR TITLE
Move buffer allocations off thread stacks

### DIFF
--- a/src/FDTunnel.cpp
+++ b/src/FDTunnel.cpp
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <algorithm>
 #include <sys/select.h>
+#include <vector>
 
 #ifdef E2DEBUG
 #include <iostream>
@@ -51,12 +52,12 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
     std::cout << thread_id << "tunnelling chunked data." << std::endl;
 #endif
         int maxlen = 32000;
-        char buff[32000];
+        std::vector<char> buff(maxlen);
         int timeout = sockfrom.getTimeout();
         int rd = 0;
         int total_rd = 0;
-        while ( (rd = sockfrom.readChunk(buff,maxlen,timeout)) > 0) {
-            sockto.writeChunk(buff, rd, timeout);
+        while ( (rd = sockfrom.readChunk(buff.data(),maxlen,timeout)) > 0) {
+            sockto.writeChunk(buff.data(), rd, timeout);
             total_rd += rd;
         }
         sockto.writeChunkTrailer(sockfrom.chunked_trailer);
@@ -110,7 +111,7 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
     else
         twayfds[1].fd = fdto;
 
-    char buff[32768]; // buffer for the input
+    std::vector<char> buff(32768); // buffer for the input
     int timeout = 120000;    // should be made setable in conf files
 
     bool done = false; // so we get past the first while
@@ -150,13 +151,19 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
 
             if (twayfds[0].revents & (POLLIN | POLLHUP))
             {
-                if (targetthroughput > -1)
+                if (targetthroughput > -1) {
                     // we have a target throughput - only read in the exact amount of data we've been told to
                     // plus 2 bytes to "solve" an IE post bug with multipart/form-data forms:
                     // adds an extra CRLF on certain requests, that it doesn't count in reported content-length
-                    rc = sockfrom.readFromSocket(buff, (((int)sizeof(buff) < ((targetthroughput - throughput) /*+2*/)) ? sizeof(buff) : (targetthroughput - throughput) /* + 2*/), 0, 0, false);
-                else
-                    rc = sockfrom.readFromSocket(buff, sizeof(buff), 0, 0, false);
+                    off_t remaining = targetthroughput - throughput;
+                    if (remaining < 0) {
+                        remaining = 0;
+                    }
+                    int readlen = static_cast<int>(std::min<off_t>(static_cast<off_t>(buff.size()), remaining /*+2*/));
+                    rc = sockfrom.readFromSocket(buff.data(), readlen, 0, 0, false);
+                } else {
+                    rc = sockfrom.readFromSocket(buff.data(), static_cast<int>(buff.size()), 0, 0, false);
+                }
 
                 // read as much as is available
                 if (rc < 0) {
@@ -176,7 +183,7 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
 
                      if (tooutfds[0].revents & POLLOUT)
                         {
-                            if (!sockto.writeToSocket(buff, rc, 0, 0, false)) { // write data
+                            if (!sockto.writeToSocket(buff.data(), rc, 0, 0, false)) { // write data
                             break; // was an error writing
                             }
 #ifdef E2DEBUG
@@ -205,7 +212,7 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
                 }
 
                 // read as much as is available
-                rc = sockto.readFromSocket(buff, sizeof(buff), 0, 0, false);
+                rc = sockto.readFromSocket(buff.data(), static_cast<int>(buff.size()), 0, 0, false);
 
                 if (rc < 0) {
                     break; // an error occurred so end the while()
@@ -220,7 +227,7 @@ bool FDTunnel::tunnel(Socket &sockfrom, Socket &sockto, bool twoway, off_t targe
 
                         if (fromoutfds[0].revents & POLLOUT)
                         {
-                        if (!sockfrom.writeToSocket(buff, rc, 0, 0, false)) { // write data
+                        if (!sockfrom.writeToSocket(buff.data(), rc, 0, 0, false)) { // write data
                             break; // was an error writing
                         }
                         done = false; // flag to say data still to be handled

--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -21,6 +21,7 @@
 #include <syslog.h>
 #include <cerrno>
 #include <zlib.h>
+#include <vector>
 
 // GLOBALS
 extern OptionContainer o;
@@ -1823,7 +1824,7 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
 
     // the RFCs don't specify a max header line length so this should be
     // dynamic really.  Pointed out (well reminded actually) by Daniel Robbins
-    char buff[32768]; // setup a buffer to hold the incomming HTTP line
+    std::vector<char> buff(32768); // setup a buffer to hold the incomming HTTP line
     String line; // temp store to hold the line after processing
     line = "----"; // so we get past the first while
     bool firsttime = true;
@@ -1842,7 +1843,7 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
 #ifdef E2DEBUG
             std::cerr << thread_id << "header:in before getLine - timeout:" << timeout << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
 #endif
-            rc = sock->getLine(buff, 32768, timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);
+            rc = sock->getLine(buff.data(), buff.size(), timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);
 #ifdef E2DEBUG
             std::cerr << thread_id << "firstime: header:in after getLine " << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
 #endif
@@ -1858,7 +1859,7 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
         //rc = sock->getLine(buff, 32768, 100, firsttime ? honour_reloadconfig : false, NULL, &truncated);   // timeout reduced to 100ms for lines after first
         // this does not work for sites who are slow to send Content-Lenght so revert to standard
         // timeout
-            rc = sock->getLine(buff, 32768, timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);   // timeout reduced to 100ms for lines after first
+            rc = sock->getLine(buff.data(), buff.size(), timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);   // timeout reduced to 100ms for lines after first
             if (rc < 0 || truncated) {
                 ispersistent = false;
 #ifdef E2DEBUG
@@ -1885,7 +1886,7 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
         // getline will throw an exception if there is an error which will
         // only be caught by HandleConnection()       ?????????????????????
 
-        if (rc > 0 ) line = buff;
+        if (rc > 0 ) line = buff.data();
         else line = "";// convert the line to a String
 
         if(firsttime && is_response) {

--- a/src/ICAPHeader.cpp
+++ b/src/ICAPHeader.cpp
@@ -21,6 +21,7 @@
 #include <syslog.h>
 #include <cerrno>
 #include <zlib.h>
+#include <vector>
 
 // GLOBALS
 extern OptionContainer o;
@@ -644,7 +645,7 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
 
     // the RFCs don't specify a max header line length so this should be
     // dynamic really.  Pointed out (well reminded actually) by Daniel Robbins
-    char buff[32768]; // setup a buffer to hold the incomming ICAP line
+    std::vector<char> buff(32768); // setup a buffer to hold the incomming ICAP line
     String line; // temp store to hold the line after processing
     line = "----"; // so we get past the first while
     bool firsttime = true;
@@ -668,7 +669,7 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
             }
 #endif
 
-            rc = sock->getLine(buff, 32768, timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);
+            rc = sock->getLine(buff.data(), buff.size(), timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);
 #ifndef NEWDEBUG_OFF
             if(o.myDebug->ICAP)
             {
@@ -693,7 +694,7 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
                 return false;
             }
         } else {
-            rc = sock->getLine(buff, 32768, timeout, firsttime ? honour_reloadconfig : false, NULL,
+            rc = sock->getLine(buff.data(), buff.size(), timeout, firsttime ? honour_reloadconfig : false, NULL,
                                &truncated);   // timeout reduced to 100ms for lines after first
             if (rc == 0) return false;
             if (rc < 0 || truncated) {
@@ -732,7 +733,7 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
         // getline will throw an exception if there is an error which will
         // only be caught by HandleConnection()       ?????????????????????
 
-        if (rc > 0) line = buff;
+        if (rc > 0) line = buff.data();
         else line = "";// convert the line to a String
 
         if (firsttime) {

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -21,6 +21,7 @@
 #include <cerrno>
 #include <unistd.h>
 #include <netinet/tcp.h>
+#include <vector>
 
 #ifdef __SSLMITM
 #include "openssl/x509v3.h"
@@ -1211,12 +1212,12 @@ int Socket::readChunk( char *buffin, int maxlen, int timeout){
 
     if(clen == 0) {
         chunked_trailer = "";
-        char trailer[32000];
+        std::vector<char> trailer(32000);
         int len = 3;
         while( len > 2) {
-            len = getLine(trailer, 31900, timeout);
+            len = getLine(trailer.data(), 31900, timeout);
             if (len > 2) {
-                chunked_trailer += trailer;
+                chunked_trailer += trailer.data();
                 chunked_trailer += "\n";
             }
         }
@@ -1251,11 +1252,11 @@ int Socket::readChunk( char *buffin, int maxlen, int timeout){
 
 int Socket::loopChunk(int timeout)    // reads chunks and sends back until 0 len chunk or timeout
 {
-    char buff[32000];
+    std::vector<char> buff(32000);
     int tot_size = 0;
     int csize = 1;
     while (csize > 0) {
-        csize = readChunk(buff,32000, timeout);
+        csize = readChunk(buff.data(),32000, timeout);
         if (csize == 0)     // end chunk
         {
             if (!writeChunkTrailer(chunked_trailer))
@@ -1271,7 +1272,7 @@ int Socket::loopChunk(int timeout)    // reads chunks and sends back until 0 len
 #endif
             return tot_size;
         }
-        if (!(csize > 0 && writeChunk(buff,csize,timeout))) {
+        if (!(csize > 0 && writeChunk(buff.data(),csize,timeout))) {
 #ifdef CHUNKDEBUG
             std::cerr << thread_id << "loopChunk - error" << std::endl;
 #endif
@@ -1285,11 +1286,11 @@ int Socket::loopChunk(int timeout)    // reads chunks and sends back until 0 len
 
 int Socket::drainChunk(int timeout)    // reads chunks until 0 len chunk or timeout
 {
-    char buff[32000];
+    std::vector<char> buff(32000);
     int tot_size = 0;
     int csize = 1;
     while (csize > 0) {
-        csize = readChunk(buff,32000, timeout);
+        csize = readChunk(buff.data(),32000, timeout);
         if (!(csize > -1 )) {
 #ifdef CHUNKDEBUG
             std::cerr << thread_id << "drainChunk - error" << std::endl;


### PR DESCRIPTION
## Summary
- move HTTP and ICAP header parsing buffers to heap-backed storage to shrink worker thread stack use
- allocate tunneling buffers dynamically and clamp read lengths when content-length is known
- shift chunked transfer helpers to heap buffers to reduce risk of stack overflows under load

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d81ddfd0832e881e0f4b9f3c7f1f)