### PR TITLE
Add option to disable man page installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,6 +332,24 @@ LIBS="${LIBS} $lfslib"
 AC_MSG_RESULT(yes)
 ])
 
+AC_MSG_CHECKING([whether to install man pages])
+AC_ARG_ENABLE(
+man,
+[AS_HELP_STRING([--enable-man@<:@=yes@:>@], [Install manual pages])],
+[ if test "x$enableval" = "xno"; then
+AC_MSG_RESULT(no)
+enable_man=no
+else
+AC_MSG_RESULT(yes)
+enable_man=yes
+fi
+],
+[ # enable by default
+AC_MSG_RESULT(yes)
+enable_man=yes
+])
+AM_CONDITIONAL(ENABLE_MAN, test "x$enable_man" = "xyes")
+
 # determine whether or not "off_t" is simply a typedef of
 # "int", "unsigned int", "long", etc. - if it is, the String
 # class won't compile if its off_t constructor is defined,

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,6 +1,9 @@
 DISTCLEANFILES = Makefile.in
 docdir = ${datadir}/doc/${PACKAGE}
 program_transform_name = s,x,x,
-dist_man_MANS = e2guardian.8
 dist_doc_DATA = AuthPlugins ContentScanners DownloadManagers FAQ FAQ.html Plugins
 EXTRA_DIST = faqconv.pl
+
+if ENABLE_MAN
+dist_man_MANS = e2guardian.8
+endif


### PR DESCRIPTION
## Summary
- add a `--disable-man` configure option so downstreams can skip installing manual pages
- guard `doc` man page installation behind the new option to avoid packaging errors when manpages are unwanted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597f8da0ec832ebb5dc045e8aa9861)