### PR TITLE
Adicionar opção configurável de tamanho de stack para threads

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -1020,6 +1020,12 @@ weightedphrasemode = 2
 # 10MB to 2MB (ulimit -s 2048)
 # default 500
 
+#threadstacksize = 0
+#
+# Stack size (in KiB) for each worker/listener/logger thread created by E2guardian.
+# Use this to mitigate stack overflows on systems with small default thread stacks.
+# Set to 0 to use the built-in default (currently 2048 KiB).
+
 #maxcontentfiltersize = 2048
 #
 # Max content filter size

--- a/src/FatController.cpp
+++ b/src/FatController.cpp
@@ -156,10 +156,24 @@ bool spawn_detached_thread(const std::function<void()> &fn, const char *desc)
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     size_t stack_size = DEFAULT_THREAD_STACK_SIZE;
+    if (o.thread_stack_size > 0) {
+        stack_size = o.thread_stack_size;
+    }
     if (stack_size < PTHREAD_STACK_MIN) {
         stack_size = PTHREAD_STACK_MIN;
     }
-    pthread_attr_setstacksize(&attr, stack_size);
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size > 0) {
+        size_t page = static_cast<size_t>(page_size);
+        stack_size = ((stack_size + page - 1) / page) * page;
+    }
+    int stack_rc = pthread_attr_setstacksize(&attr, stack_size);
+    if (stack_rc != 0) {
+        syslog(LOG_ERR, "%sFailed to set %s thread stack size to %zu bytes: %s",
+               thread_id.c_str(), desc, stack_size, strerror(stack_rc));
+        pthread_attr_destroy(&attr);
+        return false;
+    }
     pthread_t tid;
     ThreadWrapperCtx *ctx = new ThreadWrapperCtx{fn};
     int rc = pthread_create(&tid, &attr, thread_trampoline, ctx);

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -411,6 +411,20 @@ bool OptionContainer::read(std::string &filename, int type) {
             return false;
         } // check its a reasonable value
 
+        if (findoptionS("threadstacksize").empty()) {
+            thread_stack_size = 0;
+        } else {
+            long int thread_stack_kib = findoptionI("threadstacksize");
+            if (!realitycheck(thread_stack_kib, 0, 0, "threadstacksize")) {
+                return false;
+            }
+            if (thread_stack_kib <= 0) {
+                thread_stack_size = 0;
+            } else {
+                thread_stack_size = static_cast<size_t>(thread_stack_kib) * 1024;
+            }
+        }
+
         monitor_helper = findoptionS("monitorhelper");
         if (monitor_helper == "") {
             monitor_helper_flag = false;

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -120,6 +120,7 @@ class OptionContainer
     int pcon_timeout = 0;
     int pcon_timeout_sec = 0;
     int http_workers = 0;
+    size_t thread_stack_size = 0;
     std::string daemon_user_name;
     std::string daemon_group_name;
     int proxy_user = 0;


### PR DESCRIPTION
### Motivation
- Mitigar estouros de pilha (crashes com signal 4 / bad address) em cenários de carga alterando o tamanho de stack das threads sem recompilar o binário.
- Permitir ajustar o stack das threads em sistemas com limites pequenos de stack por thread (ex.: FreeBSD ou Linux com ulimit baixo). 

### Description
- Adiciona o campo `thread_stack_size` em `OptionContainer` e lê a opção de configuração `threadstacksize` (em KiB) em `OptionContainer.cpp`, guardando 0 para usar o padrão quando não definido.
- Altera `spawn_detached_thread` em `src/FatController.cpp` para usar `o.thread_stack_size` quando fornecido, aplicando `PTHREAD_STACK_MIN` como mínimo.
- Alinha o tamanho do stack ao `sysconf(_SC_PAGESIZE)` antes de chamar `pthread_attr_setstacksize` e faz log de erro com `syslog` se `pthread_attr_setstacksize` falhar, abortando a criação da thread nesse caso.
- Documenta a nova opção no arquivo de exemplo `configs/e2guardian.conf.in` com instruções e unidades (KiB). 

### Testing
- Nenhum teste automatizado foi executado como parte desta mudança.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7758e4f0832ebcae04ca2863b573)