### PR TITLE
Add configurable max header line length and improve listener exception logging

### DIFF
--- a/configs/e2guardian.conf.in
+++ b/configs/e2guardian.conf.in
@@ -817,6 +817,13 @@ usexforwardedfor = off
 # Minimum 10 max 2500
 # default 50
 
+# maxheaderlinelength = 32768
+#
+# Limit maximum length of any individual HTTP/ICAP header line (including the request line).
+# Increase this if very long URLs cause truncated header reads.
+# Minimum 4096 max 16777216
+# default 32768
+
 ###
 ### END of HEADER section
 

--- a/src/FatController.cpp
+++ b/src/FatController.cpp
@@ -1440,6 +1440,8 @@ void accept_connections(int index) // thread to listen on a single listening soc
         };
         if (!ttg) syslog(LOG_ERR, "%sError count on accept exceeds 30", thread_id.c_str());
         serversockets[index]->close();
+    } catch (const std::exception &ex) {
+       syslog(LOG_ERR, "%slistener thread caught unexpected exception exiting: %s", thread_id.c_str(), ex.what());
     } catch (...) {
        syslog(LOG_ERR,"%slistener thread caught unexpected exception exiting", thread_id.c_str());
     }

--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -1824,7 +1824,7 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
 
     // the RFCs don't specify a max header line length so this should be
     // dynamic really.  Pointed out (well reminded actually) by Daniel Robbins
-    std::vector<char> buff(32768); // setup a buffer to hold the incomming HTTP line
+    std::vector<char> buff(static_cast<size_t>(o.max_header_line_length)); // setup a buffer to hold the incomming HTTP line
     String line; // temp store to hold the line after processing
     line = "----"; // so we get past the first while
     bool firsttime = true;
@@ -1848,6 +1848,9 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
             std::cerr << thread_id << "firstime: header:in after getLine " << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
 #endif
            if (rc < 0 || truncated) {
+                if (truncated && o.logconerror) {
+                    syslog(LOG_INFO, "header:line too long (max %d bytes), see maxheaderlinelength", o.max_header_line_length);
+                }
                 ispersistent = false;
 #ifdef E2DEBUG
                 std::cerr << thread_id << "firstime: header:in after getLine: rc: " << rc << " truncated: " << truncated  << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
@@ -1861,6 +1864,9 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
         // timeout
             rc = sock->getLine(buff.data(), buff.size(), timeout, firsttime ? honour_reloadconfig : false, NULL, &truncated);   // timeout reduced to 100ms for lines after first
             if (rc < 0 || truncated) {
+                if (truncated && o.logconerror) {
+                    syslog(LOG_INFO, "header:line too long (max %d bytes), see maxheaderlinelength", o.max_header_line_length);
+                }
                 ispersistent = false;
 #ifdef E2DEBUG
                 std::cerr << thread_id << "not firstime header:in after getLine: rc: " << rc << " truncated: " << truncated << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;

--- a/src/ICAPHeader.cpp
+++ b/src/ICAPHeader.cpp
@@ -645,7 +645,7 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
 
     // the RFCs don't specify a max header line length so this should be
     // dynamic really.  Pointed out (well reminded actually) by Daniel Robbins
-    std::vector<char> buff(32768); // setup a buffer to hold the incomming ICAP line
+    std::vector<char> buff(static_cast<size_t>(o.max_header_line_length)); // setup a buffer to hold the incomming ICAP line
     String line; // temp store to hold the line after processing
     line = "----"; // so we get past the first while
     bool firsttime = true;
@@ -681,6 +681,9 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
 #endif
             if (rc == 0) return false;
             if (rc < 0 || truncated) {
+                if (truncated && o.logconerror) {
+                    syslog(LOG_INFO, "%sICAP header:line too long (max %d bytes), see maxheaderlinelength", thread_id.c_str(), o.max_header_line_length);
+                }
                 ispersistent = false;
 #ifndef NEWDEBUG_OFF
                 if(o.myDebug->ICAP)
@@ -698,6 +701,9 @@ bool ICAPHeader::in(Socket *sock, bool allowpersistent)
                                &truncated);   // timeout reduced to 100ms for lines after first
             if (rc == 0) return false;
             if (rc < 0 || truncated) {
+                if (truncated && o.logconerror) {
+                    syslog(LOG_INFO, "%sICAP header:line too long (max %d bytes), see maxheaderlinelength", thread_id.c_str(), o.max_header_line_length);
+                }
                 ispersistent = false;
 #ifndef NEWDEBUG_OFF
                 if(o.myDebug->ICAP)

--- a/src/OptionContainer.cpp
+++ b/src/OptionContainer.cpp
@@ -356,6 +356,13 @@ bool OptionContainer::read(std::string &filename, int type) {
             return false;
         }
 
+        max_header_line_length = findoptionI("maxheaderlinelength");
+        if (max_header_line_length == 0)
+            max_header_line_length = 32768;
+        if (!realitycheck(max_header_line_length, 4096, 16777216, "maxheaderlinelength")) {
+            return false;
+        }
+
 
         max_logitem_length = findoptionI("maxlogitemlength");
         // default of unlimited no longer allowed as could cause buffer overflow

--- a/src/OptionContainer.hpp
+++ b/src/OptionContainer.hpp
@@ -81,6 +81,7 @@ class OptionContainer
     int phrase_filter_mode = 0;
     int preserve_case = 0;
     unsigned int max_header_lines = 0;
+    int max_header_line_length = 0;
     int default_fg = 0;
     int default_trans_fg = 0;
     int default_icap_fg = 0;


### PR DESCRIPTION
### Motivation
- Allow increasing the maximum accepted HTTP/ICAP header line length to handle very long URLs which can cause truncated header reads. 
- Make listener thread errors easier to diagnose by including the exception message when available. 

### Description
- Add `max_header_line_length` to `OptionContainer` and parse a new `maxheaderlinelength` config option with a default of `32768` and a sanity check range (4096–16777216). 
- Document `maxheaderlinelength` in `configs/e2guardian.conf.in` and use the configured value to size the header read buffer instead of the hardcoded `32768`. 
- Log when a header read is truncated due to exceeding the configured limit by writing a `syslog` message when `truncated` is detected (controlled by `o.logconerror`) in `HTTPHeader.cpp` and `ICAPHeader.cpp`. 
- Improve listener error logging in `FatController.cpp` by catching `std::exception` and logging `ex.what()` before the existing catch-all. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were committed to the working tree and configuration template updated; compilation and runtime verification were not run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea4282fe8832e952a1cd51a9bd37a)