### PR TITLE
Corrige detecção de libresolv para suporte DNS (FreeBSD)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,7 @@ AC_MSG_CHECKING(for backside with both hands)
 AC_MSG_RESULT(no)
 AC_MSG_CHECKING(build os)
 AC_CANONICAL_BUILD
+AC_CANONICAL_HOST
 AC_MSG_RESULT($build_os)
 
 AC_MSG_CHECKING(for debug_high option)
@@ -482,7 +483,9 @@ else
 	AC_MSG_RESULT(yes)
 	dnsauth=true
 	DNSAUTHSUPPORT=""
-	LIBS="${LIBS} -lresolv"
+	AC_SEARCH_LIBS([res_init], [resolv], [], [
+		AC_MSG_ERROR([Could not find res_init; required for DNS auth support])
+	])
 	AC_DEFINE([PRT_DNSAUTH],[],[Define to enable DNS auth plugin])
 fi],
 [
@@ -591,4 +594,3 @@ src/Makefile
 ])
 
 AC_OUTPUT
-


### PR DESCRIPTION
### Motivation
- O build falhava no FreeBSD ao tentar linkar `-lresolv` diretamente para habilitar o plugin DNS auth, então é necessário detectar corretamente a presença de `res_init` em tempo de configuração.

### Description
- Atualiza `configure.ac` para adicionar `AC_CANONICAL_HOST` e substituir o `LIBS="${LIBS} -lresolv"` por `AC_SEARCH_LIBS([res_init], [resolv], [], [AC_MSG_ERROR([...])])`, garantindo busca correta da função `res_init` em vez de forçar `-lresolv`.

### Testing
- Nenhum teste automatizado foi executado após a modificação.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972bd1663d0832ebe8ea716eb934252)