### PR TITLE
Tornar ClamD opcional nas builds CMake (remover dependência por padrão)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_CXX_FLAGS -DHAVE_CONFIG_H -D__LOGLOCATION -D__PIDDIR -D__PROXYUSER -D_
 include_directories(.)
 include_directories(src)
 
+option(ENABLE_CLAMD "Enable ClamD content scanner support" OFF)
+
 add_executable(v5_5
         src/authplugins/dnsauth.cpp
         src/authplugins/header.cpp
@@ -16,7 +18,6 @@ add_executable(v5_5
         src/authplugins/ProxyFirstBasic.cpp
         src/authplugins/BearerBasic.cpp
         src/contentscanners/avastdscan.cpp
-        src/contentscanners/clamdscan.cpp
         src/contentscanners/commandlinescan.cpp
         src/contentscanners/icapscan.cpp
         src/contentscanners/kavdscan.cpp
@@ -104,3 +105,8 @@ add_executable(v5_5
         src/UDSocket.hpp
         src/UrlRec.hpp
         e2config.h)
+
+if(ENABLE_CLAMD)
+        target_sources(v5_5 PRIVATE src/contentscanners/clamdscan.cpp)
+        target_compile_definitions(v5_5 PRIVATE ENABLE_CLAMD)
+endif()


### PR DESCRIPTION
### Motivation
- Remover a dependência automática de `clamav`/ClamD do processo de build porque o antivírus não é usado e fica desabilitado na instalação padrão.

### Description
- Modificado `CMakeLists.txt` para adicionar a opção `ENABLE_CLAMD` (padrão `OFF`), remover a inclusão direta de `src/contentscanners/clamdscan.cpp` do `add_executable` e adicionar condicionalmente a fonte e a definição de compilação via `target_sources` e `target_compile_definitions` quando `ENABLE_CLAMD` estiver ativado.

### Testing
- Nenhum teste automatizado foi executado durante esta modificação (build/compilação não verificada automaticamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972c6da119c832e8699e75d6abd6611)