### PR TITLE
Adicionar configuração `bannedrooms` e regras de instalação para evitar falha no install

### DIFF
--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -2,7 +2,7 @@ DISTCLEANFILES = Makefile.in
 
 E2DATADIR = $(E2CONFDIR)/lists
 
-SUBDIRS = oldphraselists phraselists . authplugins rooms common example.group
+SUBDIRS = oldphraselists phraselists . authplugins rooms bannedrooms common example.group
 
 if NEED_CSLISTS
 SUBDIRS += contentscanners

--- a/configs/lists/README
+++ b/configs/lists/README
@@ -20,5 +20,5 @@ groupn		 - lists for group n
 oldphraselists	 - old style format phraselists
 phraselists	 - lists of phrases
 rooms      	 - location (ip) based block/allow
-
+bannedrooms	 - rooms explicitly blocked (one entry per line)
 

--- a/configs/lists/bannedrooms/Makefile.am
+++ b/configs/lists/bannedrooms/Makefile.am
@@ -1,0 +1,22 @@
+DISTCLEANFILES = Makefile.in
+
+E2DATADIR = $(E2CONFDIR)/lists/bannedrooms
+
+SUBDIRS = .
+
+WLISTS = default
+
+EXTRA_DIST = $(WLISTS)
+
+install-data-local: 
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(WLISTS) ; do \
+		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
+		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+	done
+
+
+uninstall-local:
+	for l in $(WLISTS) ; do \
+		rm -f $(DESTDIR)$(E2DATADIR)/$$l ; \
+	done

--- a/configs/lists/bannedrooms/default
+++ b/configs/lists/bannedrooms/default
@@ -1,0 +1,4 @@
+# Lista de salas bloqueadas (exemplo)
+# Adicione um identificador de sala por linha.
+# Exemplo:
+# 192.168.42.42


### PR DESCRIPTION
### Motivation
- Corrigir erro durante `make install` causado pela falta do diretório/arquivo `lists/bannedrooms/default` que provocava a falha de renomeação durante o estágio de instalação.  
- Garantir que a lista `bannedrooms` seja empacotada e instalada pelo sistema de build para alinhar com os demais subdiretórios de `configs/lists`.

### Description
- Adiciona o diretório `configs/lists/bannedrooms` com `Makefile.am` contendo regras de instalação para entregar a lista `default` no destino (`E2DATADIR`).
- Cria o arquivo de exemplo `configs/lists/bannedrooms/default` com instruções de uso (comentários).
- Inclui `bannedrooms` em `SUBDIRS` no `configs/lists/Makefile.am` para que seja processado durante a instalação.
- Atualiza `configs/lists/README` para documentar a nova subdiretório `bannedrooms`.

### Testing
- Não foram executados testes automatizados neste PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972c97da2f4832e87bacbcc6b870a57)