### PR TITLE
Adicionar arquivos .sample e compatibilidade para empacotamento do port FreeBSD

### DIFF
--- a/configs/authplugins/Makefile.am
+++ b/configs/authplugins/Makefile.am
@@ -6,7 +6,9 @@ SUBDIRS = .
 
 FLISTS = ident.conf ip.conf \
 	 port.conf pf-basic.conf  \
-	 BearerBasic.conf
+	 BearerBasic.conf \
+	 proxy-basic.conf proxy-digest.conf \
+	 proxy-header.conf proxy-ntlm.conf
 
 
 if PRT_DNSAUTH
@@ -16,13 +18,24 @@ endif
 
 EXTRA_DIST = ident.conf ip.conf \
 	     port.conf dnsauth.conf pf-basic.conf \
-	     BearerBasic.conf
+	     BearerBasic.conf proxy-basic.conf \
+	     proxy-digest.conf proxy-header.conf \
+	     proxy-ntlm.conf
+
+SAMPLE_LISTS = proxy-basic.conf proxy-digest.conf \
+	       proxy-header.conf proxy-ntlm.conf
 
 install-data-local: 
 	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
 	for l in $(FLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+	done
+	for l in $(SAMPLE_LISTS) ; do \
+		if test -f $(DESTDIR)$(E2DATADIR)/$$l ; then \
+			echo "$(INSTALL_DATA) $(DESTDIR)$(E2DATADIR)/$$l $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+			$(INSTALL_DATA) $(DESTDIR)$(E2DATADIR)/$$l $(DESTDIR)$(E2DATADIR)/$$l.sample; \
+		fi; \
 	done
 
 

--- a/configs/authplugins/proxy-basic.conf
+++ b/configs/authplugins/proxy-basic.conf
@@ -1,0 +1,28 @@
+# Proxy-Basic auth plugin
+# Identifies usernames in "Proxy-Authorization: Basic" headers;
+# relies upon the upstream proxy (squid) to perform the actual password check.
+
+plugname = 'proxy-basic'
+
+story_function = 'auth_proxy_basic'
+# This defines the storybaord function in pre-auth.story
+# which determines the filter group used.
+
+# ports - restrict this plugin to these ports
+# - default is blank = no restriction - applies to all ports
+#ports = 8081,8082
+
+# Default group settings for this plug-in
+# If these are set group determination will always succeed
+# and auth plug-in scan will stop
+# even if the user is not found in group list(s)
+
+# These settings override the global defaultfiltergroup and
+# defaulttransparentfiltergroup settings for this plug-in only.
+
+#defaultfiltergroup = 1
+# This applies to explict proxy requests
+
+#defaulttransparentfiltergroup = 2
+# This appies to transparent requests (http & https)
+# Note if not defined does NOT default to defaultfiltergroup

--- a/configs/authplugins/proxy-digest.conf
+++ b/configs/authplugins/proxy-digest.conf
@@ -1,0 +1,28 @@
+# Proxy-Digest auth plugin
+# Identifies usernames in "Proxy-Authorization: Digest" headers;
+# relies upon the upstream proxy (squid) to perform the actual password check.
+
+plugname = 'proxy-digest'
+
+story_function = 'auth_proxy_digest'
+# This defines the storybaord function in pre-auth.story
+# which determines the filter group used.
+
+# ports - restrict this plugin to these ports
+# - default is blank = no restriction - applies to all ports
+#ports = 8081,8082
+
+# Default group settings for this plug-in
+# If these are set group determination will always succeed
+# and auth plug-in scan will stop
+# even if the user is not found in group list(s)
+
+# These settings override the global defaultfiltergroup and
+# defaulttransparentfiltergroup settings for this plug-in only.
+
+#defaultfiltergroup = 1
+# This applies to explict proxy requests
+
+#defaulttransparentfiltergroup = 2
+# This appies to transparent requests (http & https)
+# Note if not defined does NOT default to defaultfiltergroup

--- a/configs/authplugins/proxy-ntlm.conf
+++ b/configs/authplugins/proxy-ntlm.conf
@@ -1,0 +1,28 @@
+# Proxy-NTLM auth plugin
+# Identifies usernames in "Proxy-Authorization: NTLM" headers;
+# relies upon the upstream proxy (squid) to perform the actual password check.
+
+plugname = 'proxy-ntlm'
+
+story_function = 'auth_proxy_ntlm'
+# This defines the storybaord function in pre-auth.story
+# which determines the filter group used.
+
+# ports - restrict this plugin to these ports
+# - default is blank = no restriction - applies to all ports
+#ports = 8081,8082
+
+# Default group settings for this plug-in
+# If these are set group determination will always succeed
+# and auth plug-in scan will stop
+# even if the user is not found in group list(s)
+
+# These settings override the global defaultfiltergroup and
+# defaulttransparentfiltergroup settings for this plug-in only.
+
+#defaultfiltergroup = 1
+# This applies to explict proxy requests
+
+#defaulttransparentfiltergroup = 2
+# This appies to transparent requests (http & https)
+# Note if not defined does NOT default to defaultfiltergroup

--- a/configs/contentscanners/Makefile.am
+++ b/configs/contentscanners/Makefile.am
@@ -38,6 +38,10 @@ install-data-local:
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
 	done
+	if test -f $(DESTDIR)$(E2DATADIR)/clamdscan.conf ; then \
+		echo "$(INSTALL_DATA) $(DESTDIR)$(E2DATADIR)/clamdscan.conf $(DESTDIR)$(E2DATADIR)/clamdscan.conf.sample"; \
+		$(INSTALL_DATA) $(DESTDIR)$(E2DATADIR)/clamdscan.conf $(DESTDIR)$(E2DATADIR)/clamdscan.conf.sample; \
+	fi
 
 
 uninstall-local:

--- a/configs/lists/Makefile.am
+++ b/configs/lists/Makefile.am
@@ -12,6 +12,33 @@ SUBDIRS += downloadmanagers
 endif
 
 WLISTS = README
+
+ROOT_SAMPLE_LISTS = addheaderregexplist \
+	authexceptioniplist authexceptionsitelist authexceptionsiteiplist \
+	authexceptionurllist bannedclientlist bannedextensionlist \
+	bannediplist bannedmimetypelist bannedphraselist \
+	bannedregexpheaderlist bannedregexpurllist \
+	bannedregexpuseragentlist bannedsearchlist \
+	bannedsearchoveridelist bannedsiteiplist bannedsitelist \
+	bannedsslsiteiplist bannedsslsitelist bannedurllist \
+	contentregexplist embededreferersiteiplist \
+	embededreferersitelist embededrefererurllist \
+	exceptionclientlist exceptionextensionlist exceptionfilesiteiplist \
+	exceptionfilesitelist exceptionfileurllist exceptioniplist \
+	exceptionmimetypelist exceptionphraselist exceptionregexpheaderlist \
+	exceptionregexpurllist exceptionregexpuseragentlist exceptionsiteiplist \
+	exceptionsitelist exceptionurllist filtergroupslist greysiteiplist \
+	greysitelist greysslsiteiplist greysslsitelist greyurllist \
+	headerregexplist localbannedsearchlist localbannedsiteiplist \
+	localbannedsitelist localbannedsslsiteiplist localbannedsslsitelist \
+	localbannedurllist localexceptionsiteiplist localexceptionsitelist \
+	localexceptionurllist localgreysiteiplist localgreysitelist \
+	localgreysslsiteiplist localgreysslsitelist localgreyurllist \
+	logregexpurllist logsiteiplist logsitelist logurllist \
+	newbannedphraselist newexceptionphraselist newweightedphraselist \
+	nocheckcertsiteiplist nocheckcertsitelist refererexceptionsiteiplist \
+	refererexceptionsitelist refererexceptionurllist searchregexplist \
+	sslsiteregexplist urlredirectregexplist urlregexplist weightedphraselist
  
 EXTRA_DIST = 
 
@@ -20,6 +47,30 @@ install-data-local:
 		for l in $(WLISTS) ; do \
 		echo "$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l"; \
 		$(INSTALL_DATA) $$l $(DESTDIR)$(E2DATADIR)/$$l; \
+	done
+	$(mkinstalldirs) $(DESTDIR)$(E2DATADIR) && \
+	for l in $(ROOT_SAMPLE_LISTS) ; do \
+		src_name=$$l; \
+		case $$l in \
+			newbannedphraselist) src_name=bannedphraselist ;; \
+			newexceptionphraselist) src_name=exceptionphraselist ;; \
+			newweightedphraselist) src_name=weightedphraselist ;; \
+		esac; \
+		src_path=; \
+		for d in $(DESTDIR)$(E2CONFDIR)/lists/example.group \
+		         $(DESTDIR)$(E2CONFDIR)/lists/common \
+		         $(DESTDIR)$(E2CONFDIR)/lists/authplugins; do \
+			if test -f $$d/$$src_name ; then \
+				src_path=$$d/$$src_name; \
+				break; \
+			fi; \
+		done; \
+		if test -z "$$src_path" ; then \
+			echo "Missing list $$src_name for root sample $$l"; \
+			exit 1; \
+		fi; \
+		echo "$(INSTALL_DATA) $$src_path $(DESTDIR)$(E2DATADIR)/$$l.sample"; \
+		$(INSTALL_DATA) $$src_path $(DESTDIR)$(E2DATADIR)/$$l.sample; \
 	done
 
 

--- a/configs/lists/common/Makefile.am
+++ b/configs/lists/common/Makefile.am
@@ -6,6 +6,7 @@ SUBDIRS = .
 
 WLISTS = authexceptioniplist \
 authexceptionsitelist \
+authexceptionsiteiplist \
 authexceptionurllist \
 bannedclientlist \
 bannediplist \

--- a/configs/lists/common/authexceptionsiteiplist
+++ b/configs/lists/common/authexceptionsiteiplist
@@ -1,0 +1,2 @@
+# Auth exception site IP list
+# One entry per line

--- a/configs/lists/oldphraselists/Makefile.am
+++ b/configs/lists/oldphraselists/Makefile.am
@@ -1,6 +1,7 @@
 DISTCLEANFILES = Makefile.in
 
 E2DATADIR = $(E2CONFDIR)/lists/oldphraselists
+LEGACYDATADIR = $(E2CONFDIR)/lists/phraselists
 PHRASELISTS = badwords chat drugadvocacy gambling games goodphrases \
 		googlesearches gore illegaldrugs intolerance legaldrugs \
 		malware news nudism peer2peer personals pornography \
@@ -11,10 +12,13 @@ PHRASELISTS = badwords chat drugadvocacy gambling games goodphrases \
 install-data-local: 
 	for l in $(PHRASELISTS); do \
 		$(mkinstalldirs) $(DESTDIR)$(E2DATADIR)/$$l && \
+		$(mkinstalldirs) $(DESTDIR)$(LEGACYDATADIR)/$$l && \
 		for f in $(srcdir)/$$l/weighted* $(srcdir)/$$l/exception* $(srcdir)/$$l/banned*; do \
 		   if test -f $$f ; then \
 			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$l"; \
 			$(INSTALL_DATA) $$f $(DESTDIR)$(E2DATADIR)/$$l; \
+			echo "$(INSTALL_DATA) $$f $(DESTDIR)$(LEGACYDATADIR)/$$l"; \
+			$(INSTALL_DATA) $$f $(DESTDIR)$(LEGACYDATADIR)/$$l; \
 	           fi \
 		done \
 	done


### PR DESCRIPTION
### Motivation
- Corrigir falhas de empacotamento observadas no port FreeBSD onde o processo esperava diversos ficheiros `*.sample` e listas de phraselists que não existiam. 
- Garantir que as listas legadas e configurações de plugins de autenticação estejam disponíveis para o staging do port e2guardian.

### Description
- Adicionei stubs de configuração para os plugins `proxy-basic`, `proxy-digest` e `proxy-ntlm` em `configs/authplugins/` e atualizei `configs/authplugins/Makefile.am` para incluir estes ficheiros e instalar cópias `.sample` quando apropriado. 
- Ajustei `configs/contentscanners/Makefile.am` para gerar `clamdscan.conf.sample` quando `clamdscan.conf` estiver presente durante a instalação. 
- Atualizei `configs/lists/Makefile.am` para gerar as entradas de amostra de listas no diretório raiz (`.sample`) esperado pelo port e adicionei lógica para mapear `new*` para as listas existentes (`banned`, `exception`, `weighted`). 
- Modifiquei `configs/lists/oldphraselists/Makefile.am` para também instalar ficheiros legacy em `lists/phraselists` (copiar as listas antigas para o layout legado) e adicionei a lista faltante `configs/lists/common/authexceptionsiteiplist`.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d2ac2e48832eb84c4219901ed42d)