### PR TITLE
Guard against empty header deque to prevent deque::front crash

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -900,6 +900,9 @@ void HTTPHeader::dbshowheader(bool outgoing)
 // are case-insensitive. - Anonymous SF Poster, 2006-02-23
 void HTTPHeader::checkheader(bool allowpersistent)
 {
+    if (header.empty()) {
+        return;
+    }
     bool outgoing = !is_response;
 //    if (header.front().startsWith("HT")) {
 //        outgoing = false;
@@ -1930,6 +1933,9 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
     }
 
     header.pop_back(); // remove the final blank line of a header
+    if (header.empty()) {
+        return false;
+    }
 #ifdef E2DEBUG
     std::cerr << thread_id << "header:size =  " << header.size() << std::endl;
     if (header.size() > 0)


### PR DESCRIPTION
### Motivation
- A crash was observed when `deque::front` was called on an empty header deque inside `HTTPHeader::checkheader` after `HTTPHeader::in` had removed the trailing blank line with `pop_back()`; malformed or noisy input can make the deque empty.  
- The intended behavior for malformed headers is to abort parsing and return `false` rather than dereference an empty container and crash.

### Description
- Add a defensive empty check at the start of `HTTPHeader::checkheader` with `if (header.empty()) { return; }` to avoid calling `header.front()` on an empty deque.  
- After `header.pop_back()` in `HTTPHeader::in`, add `if (header.empty()) { return false; }` so parsing is aborted when removing the trailing blank line leaves the header empty.  
- These changes make malformed or incomplete input safely fail header processing without changing the expected behavior for valid requests.

### Testing
- No automated tests were run for this change.  
- Change was applied to `src/HTTPHeader.cpp` and reviewed locally for correctness; no build or unit test execution was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bb50344c832ea892339450a95a4c)