### PR TITLE
Add defensive empty-header checks across HTTPHeader and FreeBSD debug docs

### DIFF
--- a/doc/freebsd-core-dump.md
+++ b/doc/freebsd-core-dump.md
@@ -1,0 +1,94 @@
+# Captura de core dump no FreeBSD/pfSense
+
+> Objetivo: habilitar core dumps para diagnosticar falhas (ex.: processos saindo com sinal 4).
+
+## 1) Verificar status atual
+
+```sh
+sysctl kern.coredump
+sysctl kern.corefile
+sysctl kern.sugid_coredump
+```
+
+## 2) Ativar core dumps (sessão atual)
+
+```sh
+sysctl kern.coredump=1
+sysctl kern.corefile=/var/coredumps/%N.%P.core
+```
+
+> `%N` = nome do binário, `%P` = PID.
+
+Se o processo for setuid/setgid, habilite também:
+
+```sh
+sysctl kern.sugid_coredump=1
+```
+
+## 3) Persistir as mudanças
+
+Em FreeBSD/pfSense, adicione em `/etc/sysctl.conf`:
+
+```
+kern.coredump=1
+kern.corefile=/var/coredumps/%N.%P.core
+kern.sugid_coredump=1
+```
+
+> Ajuste `kern.sugid_coredump` somente se for necessário. Em ambientes de produção
+> pode haver restrições de segurança.
+
+## 4) Garantir diretório de destino e permissões
+
+```sh
+mkdir -p /var/coredumps
+chmod 1777 /var/coredumps
+```
+
+## 5) Remover limites de core dump (ulimit)
+
+Verifique o limite atual:
+
+```sh
+ulimit -c
+```
+
+Para permitir core dumps na sessão atual:
+
+```sh
+ulimit -c unlimited
+```
+
+Para serviços iniciados via rc, use um wrapper de serviço ou ajuste a classe de
+login apropriada para o usuário do daemon, garantindo `coredumpsize=unlimited`.
+
+## 6) Validar geração do core
+
+Forçar um core (em um processo de teste) ajuda a validar o fluxo. Por exemplo:
+
+```sh
+kill -ABRT <PID>
+```
+
+Se tudo estiver correto, um arquivo deve aparecer em `/var/coredumps/`.
+
+## 7) Capturar core do e2guardian em execução
+
+Com o e2guardian rodando (ex.: `/usr/local/sbin/e2guardian`), você pode gerar
+um core manualmente após confirmar que os ajustes acima estão ativos:
+
+```sh
+ps -axu | grep e2guardian
+kill -ABRT <PID_DO_E2GUARDIAN>
+```
+
+> Observação: o processo vai encerrar com sinal e o core será gravado em
+> `/var/coredumps/` se `ulimit -c` e os `sysctl` estiverem corretos.
+
+## 8) Localizar e analisar o core
+
+```sh
+ls -lh /var/coredumps/
+```
+
+Depois, use `gdb`/`lldb` com o binário e o core para obter backtrace.

--- a/doc/port-debug-build.md
+++ b/doc/port-debug-build.md
@@ -1,0 +1,40 @@
+# Sugestão de build com símbolos de debug (pfSense/FreeBSD port)
+
+Abaixo está uma sugestão de ajuste no Makefile do port para gerar binários com
+símbolos de debug quando a opção `DEBUG` estiver habilitada.
+
+## 1) Adicionar flags de debug (C/C++)
+
+```make
+DEBUG_CFLAGS=   -g -O0 -fno-omit-frame-pointer
+DEBUG_CXXFLAGS= -g -O0 -fno-omit-frame-pointer
+```
+
+Essas flags geram símbolos (`-g`) e evitam otimizações que dificultam o backtrace.
+
+## 2) Evitar stripping do binário em modo debug
+
+Para manter os símbolos no binário, desabilite o `strip` quando `DEBUG` estiver
+ativo. Em ports, isso pode ser feito ao adicionar:
+
+```make
+DEBUG_VARS= STRIP=
+```
+
+Evite usar `.if ${PORT_OPTIONS:MDEBUG}` antes de incluir
+`bsd.port.options.mk`, pois `PORT_OPTIONS` ainda não existe durante `make config`.
+
+## 3) Exemplo de bloco completo
+
+```make
+OPTIONS_DEFINE=  CLISCAN ICAP NTLM DNS EMAIL DEBUG DOCS SSL_MITM
+
+DEBUG_CONFIGURE_OFF=     --with-dgdebug=off --with-newdebug=off
+DEBUG_CONFIGURE_ON=      --with-dgdebug=on --with-newdebug=on
+DEBUG_CFLAGS=            -g -O0 -fno-omit-frame-pointer
+DEBUG_CXXFLAGS=          -g -O0 -fno-omit-frame-pointer
+DEBUG_VARS=              STRIP=
+```
+
+Depois disso, compile o port com a opção `DEBUG` habilitada para que o
+`/usr/local/sbin/e2guardian` tenha símbolos e o GDB consiga resolver as funções.

--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -407,6 +407,9 @@ void HTTPHeader::makeTransparent(bool incoming)
 #ifdef E2DEBUG
     std::cerr << thread_id << "Making headers transparent" << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
 #endif
+    if (header.empty()) {
+        return;
+    }
     if (incoming) {
         // remove references to the proxy before sending to browser
         if (pproxyconnection != NULL) {
@@ -519,6 +522,9 @@ void HTTPHeader::removeEncoding(int newlen)
 // setURL Code originally from from Ton Gorter 2004
 void HTTPHeader::setURL(String &url)
 {
+    if (header.empty()) {
+        return;
+    }
     String hostname;
     bool https = (url.before("://") == "https");
     if(requestType() == "CONNECT"){
@@ -584,6 +590,9 @@ void HTTPHeader::setURL(String &url)
 }
 
 void HTTPHeader::setConnect(String &con_site) {
+    if (header.empty()) {
+        return;
+    }
     if (requestType() != "CONNECT") return;
     header.front() = header.front().before(" ") + " " + con_site + ":" + String(port) + " " + header.front().after(" ").after(" ");
     //remove all other headers
@@ -991,6 +1000,10 @@ void HTTPHeader::checkheader(bool allowpersistent)
     }
 }
 
+    if (header.empty()) {
+        return false;
+    }
+
     //if its http1.1
     bool onepointone = false;
     if (header.front().after("HTTP/").startsWith("1.1")) {
@@ -1257,6 +1270,9 @@ String HTTPHeader::url()
 // Ernest W Lessenger
 void HTTPHeader::chopBypass(String url, bool infectionbypass)
 {
+    if (header.empty()) {
+        return;
+    }
     if (url.contains(infectionbypass ? "GIBYPASS=" : "GBYPASS=")) {
         if (url.contains(infectionbypass ? "?GIBYPASS=" : "?GBYPASS=")) {
             String bypass(url.after(infectionbypass ? "?GIBYPASS=" : "?GBYPASS="));
@@ -1272,6 +1288,9 @@ void HTTPHeader::chopBypass(String url, bool infectionbypass)
 // same for scan bypass
 void HTTPHeader::chopScanBypass(String url)
 {
+    if (header.empty()) {
+        return;
+    }
     if (url.contains("GSBYPASS=")) {
         if (url.contains("?GSBYPASS=")) {
             String bypass(url.after("?GSBYPASS="));
@@ -1930,6 +1949,12 @@ bool HTTPHeader::in(Socket *sock, bool allowpersistent)
     }
 
     header.pop_back(); // remove the final blank line of a header
+#ifdef E2DEBUG
+    std::cerr << thread_id << "header:size after pop_back = " << header.size() << std::endl;
+#endif
+    if (header.empty()) {
+        return false;
+    }
 #ifdef E2DEBUG
     std::cerr << thread_id << "header:size =  " << header.size() << std::endl;
     if (header.size() > 0)


### PR DESCRIPTION
### Motivation
- Prevent crashes from calling `header.front()` on an empty `std::deque` during header parsing and manipulation. 
- Harden header rewriting and URL manipulation codepaths so they safely handle empty headers instead of dereferencing the first element. 
- Improve post-mortem debugging and local build debugability on FreeBSD/pfSense by documenting core-dump and debug-port build steps.

### Description
- Add early-return guards that check `header.empty()` in `HTTPHeader::makeTransparent`, `HTTPHeader::setURL`, `HTTPHeader::setConnect`, `HTTPHeader::chopBypass`, and `HTTPHeader::chopScanBypass` to avoid accessing `header.front()` on an empty deque. 
- In `checkheader` add a defensive `return false` when `header` is empty before using `header.front()`, and in `in` add an `E2DEBUG` log of `header.size()` after `header.pop_back()` and a guard that returns when `header` becomes empty. 
- Add `doc/freebsd-core-dump.md` with steps to enable and capture core dumps on FreeBSD/pfSense and `doc/port-debug-build.md` with guidance to build the port with debug symbols and avoid stripping symbols.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697384545c8c832eb3fad40343997205)