### PR TITLE
Proteger contra acessos a `deque::front()` em headers/buffers vazios

### DIFF
--- a/src/BackedStore.cpp
+++ b/src/BackedStore.cpp
@@ -111,11 +111,13 @@ bool BackedStore::append(const char *data, size_t len)
 
             size_t bytes_written = 0;
             ssize_t rc = 0;
-            do {
-                rc = write(fd, &(rambuf.front()) + bytes_written, rambuf.size() - bytes_written);
-                if (rc > 0)
-                    bytes_written += rc;
-            } while (bytes_written < rambuf.size() && (rc > 0 || errno == EINTR));
+            if (!rambuf.empty()) {
+                do {
+                    rc = write(fd, &(rambuf.front()) + bytes_written, rambuf.size() - bytes_written);
+                    if (rc > 0)
+                        bytes_written += rc;
+                } while (bytes_written < rambuf.size() && (rc > 0 || errno == EINTR));
+            }
             if (rc < 0 && errno != EINTR) {
                 std::ostringstream ss;
                 ss << thread_id << "BackedStore could not dump RAM buffer to temp file: " << strerror(errno);
@@ -191,6 +193,9 @@ const char *BackedStore::getData() const
 #ifdef E2DEBUG
         std::cerr << thread_id << "BackedStore: returning pointer to RAM" << std::endl;
 #endif
+        if (rambuf.empty()) {
+            return "";
+        }
         return &(rambuf.front());
     } else {
 #ifdef E2DEBUG
@@ -268,7 +273,7 @@ std::string BackedStore::store(const char *prefix)
             if (rc > 0)
                 bytes_written += rc;
         } while (bytes_written < length && (rc > 0 || errno == EINTR));
-    } else {
+    } else if (!rambuf.empty()) {
         do {
             rc = write(storefd, &(rambuf.front()) + bytes_written, rambuf.size() - bytes_written);
             if (rc > 0)

--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -1007,12 +1007,12 @@ void HTTPHeader::checkheader(bool allowpersistent)
 }
 
     if (header.empty()) {
-        return false;
+        return;
     }
 
     //if its http1.1
     bool onepointone = false;
-    const String &firstline = header.front();
+    String firstline = header.front();
     if (firstline.after("HTTP/").startsWith("1.1")) {
 #ifdef E2DEBUG
         std::cerr << thread_id << "CheckHeader: HTTP/1.1 detected" << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;

--- a/src/ICAPHeader.cpp
+++ b/src/ICAPHeader.cpp
@@ -128,6 +128,9 @@ void ICAPHeader::reset()
 // grab request type (REQMOD, RESPMOD, OPTIONS)
 String ICAPHeader::requestType()
 {
+    if (header.empty()) {
+        return "";
+    }
     return header.front().before(" ");
 }
 

--- a/src/contentscanners/icapscan.cpp
+++ b/src/contentscanners/icapscan.cpp
@@ -763,12 +763,15 @@ int icapinstance::doScan(Socket &icapsock, HTTPHeader *docheader, const char *ob
                 if(o.myDebug->ICAPC)
                 {
                         std::ostringstream oss (std::ostringstream::out);
+                        const char *original_header_line = docheader->header.empty()
+                            ? "<header vazio>"
+                            : docheader->header.front().toCharArray();
                         oss << thread_id << "Comparing original return code to modified:" 
-                          << docheader->header.front() << std::endl
+                          << original_header_line << std::endl
                           << line << std::endl;
                         o.myDebug->Debug("ICAPC",oss.str());
                         std::cerr << thread_id <<  "Comparing original return code to modified:" 
-                          << docheader->header.front() << std::endl
+                          << original_header_line << std::endl
                           << line << std::endl;
                 }
 #endif


### PR DESCRIPTION
### Motivation
- Corrigir crash observado onde `deque::front()` era chamado em `header` vazio (causando assert da libc++ e SIGILL) conforme o backtrace do core dump; a investigação mostrou múltiplos locais que podiam aceder a `header.front()` ou a `rambuf.front()` sem garantias de não-vazio.
- Tornar os pontos críticos do parser e do armazenamento temporário mais resilientes a entradas/parsers malformados e headers ausentes, reduzindo risco de falhas em produção.

### Description
- Em `src/HTTPHeader.cpp` evitei ler `header.front()` quando `header` está vazio ao retornar imediatamente em `HTTPHeader::checkheader(bool)`, e passei de `const String &firstline = header.front()` para `String firstline = header.front()` para eliminar referências dependentes do contêiner.
- Em `src/ICAPHeader.cpp` adicionei verificação em `ICAPHeader::requestType()` para retornar `""` quando `header` estiver vazio, prevenindo acessos inválidos a `front()`.
- Em `src/BackedStore.cpp` protegi chamadas que usam `rambuf.front()` verificando `rambuf.empty()` antes de escrever para ficheiro ou devolver ponteiro, e ajustei a lógica de escrita para não tentar gravar quando o buffer RAM estiver vazio.
- Em `src/contentscanners/icapscan.cpp` tornei o log de debug resiliente a headers vazios ao escolher uma string segura (`"<header vazio>"`) em vez de usar `docheader->header.front()` diretamente.

### Testing
- Nenhum teste automatizado foi executado nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777c40d5b0832e8c527313566b4e83)