### PR TITLE
Serializar acesso ao deque de headers para evitar condição de corrida

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -42,6 +42,7 @@ void HTTPHeader::setTimeout(int t)
 // reset header object for future use
 void HTTPHeader::reset()
 {
+    std::lock_guard<std::recursive_mutex> lock(header_mutex);
     if (dirty) {
         header.clear();
         waspersistent = false;
@@ -591,6 +592,7 @@ void HTTPHeader::setURL(String &url)
 }
 
 void HTTPHeader::setConnect(String &con_site) {
+    std::lock_guard<std::recursive_mutex> lock(header_mutex);
     if (header.empty()) {
         return;
     }
@@ -913,9 +915,11 @@ void HTTPHeader::dbshowheader(bool outgoing)
 // are case-insensitive. - Anonymous SF Poster, 2006-02-23
 void HTTPHeader::checkheader(bool allowpersistent)
 {
+    std::lock_guard<std::recursive_mutex> lock(header_mutex);
     if (header.empty()) {
         return;
     }
+    String firstline = header.front();
     bool outgoing = !is_response;
 //    if (header.front().startsWith("HT")) {
 //        outgoing = false;
@@ -1007,13 +1011,8 @@ void HTTPHeader::checkheader(bool allowpersistent)
     }
 }
 
-    if (header.empty()) {
-        return;
-    }
-
     //if its http1.1
     bool onepointone = false;
-    String firstline = header.front();
     if (firstline.after("HTTP/").startsWith("1.1")) {
 #ifdef E2DEBUG
         std::cerr << thread_id << "CheckHeader: HTTP/1.1 detected" << " Line: " << __LINE__ << " Function: " << __func__ << std::endl;
@@ -1841,6 +1840,7 @@ bool HTTPHeader::in_handle_100(Socket *sock, bool allowpersistent, bool expect_1
 
 bool HTTPHeader::in(Socket *sock, bool allowpersistent)
 {
+    std::lock_guard<std::recursive_mutex> lock(header_mutex);
     if (dirty)
         reset();
     dirty = true;

--- a/src/HTTPHeader.hpp
+++ b/src/HTTPHeader.hpp
@@ -17,6 +17,7 @@
 // INCLUDES
 
 #include <deque>
+#include <mutex>
 
 #include "String.hpp"
 //#include "DataBuffer.hpp"
@@ -214,6 +215,7 @@ class HTTPHeader
     };
 
        private:
+        mutable std::recursive_mutex header_mutex;
         // timeout for socket operations
         int timeout;
 


### PR DESCRIPTION
### Motivation
- Identificar e eliminar uma condição de corrida onde o `deque` `header` podia ser esvaziado enquanto outro código o iterava, causando chamadas inseguras a `front()`/iteradores e potencial crash. 
- Os pontos que limpam/encolhem o deque incluem `reset()` (`header.clear()`), `setConnect()` (`header.erase(...)`) e `header.pop_back()` em `in()`, portanto foi necessário garantir acesso serializado ao objeto.

### Description
- Adiciona `#include <mutex>` e um `mutable std::recursive_mutex header_mutex` à classe `HTTPHeader` em `src/HTTPHeader.hpp` para proteção de concorrência.
- Protege com `std::lock_guard<std::recursive_mutex>` o acesso ao deque `header` nas funções `reset()`, `setConnect()`, `checkheader()` e `in()` em `src/HTTPHeader.cpp` para evitar modificações concorrentes durante leitura/iteração.
- Captura a `firstline` sob a mesma proteção antes de chamar `front()` em `checkheader()` para garantir que não será lida de um deque vazio enquanto se itera nas linhas.
- Arquivos modificados: `src/HTTPHeader.hpp` e `src/HTTPHeader.cpp`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69781570cf08832e92cfcd82c46cfdb4)