### PR TITLE
Protege acesso ao header e corrige bug de autorização em HTTPHeader

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -524,6 +524,7 @@ void HTTPHeader::removeEncoding(int newlen)
 // setURL Code originally from from Ton Gorter 2004
 void HTTPHeader::setURL(String &url)
 {
+    std::lock_guard<std::recursive_mutex> lock(header_mutex);
     if (header.empty()) {
         return;
     }
@@ -971,7 +972,7 @@ void HTTPHeader::checkheader(bool allowpersistent)
             pcontentdisposition = &(*i);
         } else if ((pproxyauthorization == NULL) && i->startsWithLower("proxy-authorization:")) {
             pproxyauthorization = &(*i);
-        } else if ((pauthorization = NULL) && i->startsWithLower("authorization:")) {
+        } else if ((pauthorization == NULL) && i->startsWithLower("authorization:")) {
             pauthorization = &(*i);
         } else if ((pproxyauthenticate == NULL) && i->startsWithLower("proxy-authenticate:")) {
             pproxyauthenticate = &(*i);


### PR DESCRIPTION
### Motivation
- Pelo core dump, o processo recebeu `SIGILL` devido a um assert do libc++ em `deque::front()` (deque vazio) dentro de `HTTPHeader::checkheader`, indicando uma possível condição de corrida ou acesso concorrente que deixou o deque de headers vazio no momento do acesso.

### Description
- Adiciona `std::lock_guard<std::recursive_mutex>` em `HTTPHeader::setURL` para sincronizar o acesso ao `header` e reduzir o risco de leitura de `header.front()` enquanto outro thread modifica ou limpa o deque, e corrige a condição que inadvertidamente atribuía `NULL` ao ponteiro `pauthorization` trocando `(pauthorization = NULL)` por `(pauthorization == NULL)` em `src/HTTPHeader.cpp`.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978aa820fec832e99f871496ef12533)