### PR TITLE
Warn on trusting X-Forwarded-For, reject group 0, and guard `setgroup` to avoid sticky groups

### DIFF
--- a/doc/troubleshooting-ip-auth-group-drift.md
+++ b/doc/troubleshooting-ip-auth-group-drift.md
@@ -1,0 +1,48 @@
+# Troubleshooting: all users suddenly matching the first IP auth group
+
+If e2guardian starts placing every client into the first filter group (for
+example `SEM-BLOQUEIO`) until service restart, check the items below.
+
+## 1) `usexforwardedfor` can collapse all users into one source IP
+
+With the `ip` auth plugin, when `usexforwardedfor=on`, e2guardian prioritizes
+the IP extracted from `X-Forwarded-For` before socket/client fallback values.
+If all requests arrive with the same forwarded IP (or a spoofed header), every
+user maps to the same group.
+
+## 2) Catch-all subnets in `ipgroups` win by order
+
+Subnet entries are evaluated in list order, and the first match wins. A broad
+entry such as `0.0.0.0/0=1` near the top will effectively send everyone to a
+single group.
+
+## 2b) Group can be overridden after IP auth (`setgroup`)
+
+Even when IP auth identifies users correctly, StoryBoard rules can later force
+another filter group via `setgroup`. In this case, logs still show different
+user IPs, but the final group column becomes the same for many/all requests.
+
+Recent hardening ignores `setgroup` when it is used without a list-derived
+result (for example, attached to non-list states), reducing accidental
+"sticky group" behavior from stale intermediate values.
+
+## 3) Invalid group `0` in `ipgroups`
+
+`ipgroups` values are 1-based (`1..filtergroups`). Group `0` is invalid and
+must be rejected. A typo like `192.168.1.10=0` can unintentionally force a
+match to the first group if not validated strictly.
+
+## Fast validation checklist
+
+1. Confirm `authplugins/ip.conf` and `lists/authplugins/ipgroups` did not
+   change unexpectedly.
+2. If `usexforwardedfor=on`, verify `xforwardedforfilterip` is explicitly set
+   only for trusted upstream proxies.
+3. Search `ipgroups` for `=0`, `group0`, and broad CIDRs/ranges.
+4. Enable auth debug logs and compare chosen user IP vs. peer IP/XFF.
+
+## Operational note
+
+Recent code logs a warning when `usexforwardedfor=on` and
+`xforwardedforfilterip` is empty, because this trusts `X-Forwarded-For` from
+all peers and can collapse user identification unexpectedly.

--- a/src/StoryBoard.cpp
+++ b/src/StoryBoard.cpp
@@ -919,6 +919,11 @@ bool StoryBoard::runFunct(unsigned int fID, NaughtyFilter &cm) {
                 case SB_FUNC_SETGROUP:
                     action_return = false;
                     {
+                        // setgroup expects a group label/id coming from a matched list result.
+                        // Avoid reusing stale cm.result values when this action is attached to
+                        // non-list states (e.g. "true"), which can force unintended group stickiness.
+                        if (!(isListCheck || isHeaderCheck || isMultiListCheck) || cm.result.size() == 0)
+                            break;
                         int g = resolve_filter_group_from_label(cm.result);
                         if (g > 0 && g <= o.numfg) {
                             cm.filtergroup = g - 1;

--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -113,6 +113,7 @@ class ipinstance : public AuthPlugin
     bool ipgroups_loaded_ = false;
     bool ipgroups_parse_error_logged_ = false;
     int ipgroups_reload_id_ = -1;
+    bool xff_no_filter_warned_ = false;
     std::mutex ipgroups_mutex_;
 
     bool ensureIPGroupsLoadedLocked();
@@ -472,6 +473,16 @@ int ipinstance::identify(Socket &peercon, Socket &proxycon, HTTPHeader &h, std::
                 }
             }
         } else {
+            if (!xff_no_filter_warned_) {
+                if (!is_daemonised)
+                    std::cerr << thread_id
+                              << "IP auth plugin: usexforwardedfor is enabled with empty xforwardedforfilterip; "
+                              << "trusting X-Forwarded-For from all peers" << std::endl;
+                syslog(LOG_WARNING,
+                       "%s",
+                       "IP auth plugin: usexforwardedfor is enabled with empty xforwardedforfilterip; trusting X-Forwarded-For from all peers");
+                xff_no_filter_warned_ = true;
+            }
             use_xforwardedfor = true;
         }
     }
@@ -697,14 +708,8 @@ int ipinstance::parseFilterGroup(const String &value, const char *filename, cons
         }
     }
 
-    bool has_digits = digits.length() > 0;
-    String numeric = has_digits ? digits : normalised;
+    String numeric = (digits.length() > 0) ? digits : normalised;
     int group = numeric.toInteger();
-    if (has_digits && group == 0) {
-        if (o.filter_groups > 0)
-            return 0;
-        group = -1;
-    }
     if ((group < 1) || (group > o.filter_groups)) {
         if (!is_daemonised)
             std::cerr << thread_id << "Filter group out of range; entry " << line << " in " << filename << std::endl;


### PR DESCRIPTION
### Motivation

- Prevent many clients from being collapsed into the same filter group when `usexforwardedfor` is enabled without a trusted-filter list. 
- Prevent `setgroup` actions attached to non-list states from reusing stale `cm.result` values and causing unintended "sticky" filter groups. 
- Ensure invalid group label `0` is treated as out-of-range rather than silently mapping users to the first filter group.

### Description

- Add a new troubleshooting document `doc/troubleshooting-ip-auth-group-drift.md` that explains common causes for all users mapping to the same filter group and provides a fast validation checklist. 
- In `src/authplugins/ip.cpp` add a one-time warning (`syslog` and `stderr`) when `usexforwardedfor` is enabled but `xforwardedforfilterip` is empty, and track the warning with `xff_no_filter_warned_` so it is emitted only once. 
- In `src/authplugins/ip.cpp` simplify filter-group parsing and remove the special-case handling that allowed a parsed `0` to map to a valid group, making `0` now be treated as out-of-range and rejected. 
- In `src/StoryBoard.cpp` guard the `SB_FUNC_SETGROUP` action so it only applies when attached to list/header/multilist checks and when `cm.result` is non-empty, avoiding reuse of stale results and accidental group overrides.

### Testing

- Project built successfully after the changes using the normal build process (`make`).
- Project unit test suite was executed (`make check`) and completed without failures. 
- Basic static/logging checks were validated to ensure the X-Forwarded-For warning is emitted once when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cae1f56598832ebe1b4eb9280ce1d2)