### PR TITLE
SocketArray: add IP×port binding modes, manage lc_types lifecycle, and bump release version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_DEFINE([__SSLMITM],[""],[Define to enable SSL MITM])
 
 AC_PREREQ(2.57)
-AC_INIT(e2guardian, 5.4.10_5)
+AC_INIT(e2guardian, 5.4.10_6)
 AC_CONFIG_HEADERS([e2config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/e2guardian.release
+++ b/e2guardian.release
@@ -1,4 +1,4 @@
-This the v5.4 stable branch 
+This the v5.4.10_6 stable branch
 ---------------------------
 
 See notes/NEWIN_v5 for details of development progress and
@@ -6,7 +6,7 @@ target new features and improvements.
 
 See ./README.md for delails of this release.
 
-Changed and Added features in e2guardian 5.0 
+Changed and Added features in e2guardian 5.0
 --------------------------------------------
 
 Complete change to list handling and logic control.
@@ -26,10 +26,10 @@ Changed and Added features in e2guardian 4.0.0
 ----------------------------------------------
 
 Major internal rewrite to improve code quality, stability and performance
-The main advantage is the engine itself. It is more faster and powerful than before and tuning FD_SETSIZE is not needed anymore 
+The main advantage is the engine itself. It is more faster and powerful than before and tuning FD_SETSIZE is not needed anymore
 
 
-Tuning settings introduced/changed in v4.0.0:- 
+Tuning settings introduced/changed in v4.0.0:-
 --------------------------------------------
 
 e2guardian.conf

--- a/src/SocketArray.cpp
+++ b/src/SocketArray.cpp
@@ -33,6 +33,7 @@ void SocketArray::deleteAll()
     delete[] drawer;
     drawer = NULL;
     socknum = 0;
+    lc_types.clear();
 }
 
 // close all sockets & create new ones
@@ -42,6 +43,7 @@ void SocketArray::reset(int sockcount)
 
     drawer = new Socket[sockcount];
     socknum = sockcount;
+    lc_types.clear();
 }
 
 // bind our first socket to any IP
@@ -125,25 +127,60 @@ int SocketArray::listenAll(int queue)
 // bind all sockets to given IP list
 int SocketArray::bindAll(std::deque<String> &ips, std::deque<String> &ports)
 {
-    if (ips.size() > socknum) {
+    if (ips.empty() || ports.empty()) {
         return -1;
     }
-    //for (unsigned int i = 0; i < socknum; i++) {
-    for (unsigned int i = 0; i < ips.size(); i++) {
-#ifdef E2DEBUG
-        std::cerr << thread_id << "Binding server socket[" << ports[i] << " " << ips[i] << " " << i << "])" << std::endl;
-#endif
-        if (drawer[i].bind(ips[i].toCharArray(), ports[i].toInteger())) {
-            if (!is_daemonised) {
-                std::cerr << thread_id << "Error binding server socket: ["
-                          << ports[i] << " " << ips[i] << " " << i << "] (" << strerror(errno) << ")" << std::endl;
-            }
-            syslog(LOG_ERR, "Error binding socket: [%s %s %d] (%s)", ports[i].toCharArray(), ips[i].toCharArray(), i, strerror(errno));
+
+    const unsigned int mapped_count = ips.size();
+    const unsigned int matrix_count = ips.size() * ports.size();
+
+    // mapportstoips=on -> one-to-one IP/port mapping
+    if (socknum == mapped_count) {
+        if (ports.size() != ips.size()) {
             return -1;
         }
-        lc_types.push_back(CT_PROXY);
+
+        for (unsigned int i = 0; i < ips.size(); i++) {
+#ifdef E2DEBUG
+            std::cerr << thread_id << "Binding server socket[" << ports[i] << " " << ips[i] << " " << i << "])" << std::endl;
+#endif
+            if (drawer[i].bind(ips[i].toCharArray(), ports[i].toInteger())) {
+                if (!is_daemonised) {
+                    std::cerr << thread_id << "Error binding server socket: ["
+                              << ports[i] << " " << ips[i] << " " << i << "] (" << strerror(errno) << ")" << std::endl;
+                }
+                syslog(LOG_ERR, "Error binding socket: [%s %s %d] (%s)", ports[i].toCharArray(), ips[i].toCharArray(), i, strerror(errno));
+                return -1;
+            }
+            lc_types.push_back(CT_PROXY);
+        }
+        return 0;
     }
-    return 0;
+
+    // mapportstoips=off -> bind all IP x port combinations
+    if (socknum == matrix_count) {
+        unsigned int idx = 0;
+        for (unsigned int i = 0; i < ips.size(); i++) {
+            for (unsigned int p = 0; p < ports.size(); p++) {
+#ifdef E2DEBUG
+                std::cerr << thread_id << "Binding server socket[" << ports[p] << " " << ips[i] << " " << idx << "])" << std::endl;
+#endif
+                if (drawer[idx].bind(ips[i].toCharArray(), ports[p].toInteger())) {
+                    if (!is_daemonised) {
+                        std::cerr << thread_id << "Error binding server socket: ["
+                                  << ports[p] << " " << ips[i] << " " << idx << "] (" << strerror(errno) << ")" << std::endl;
+                    }
+                    syslog(LOG_ERR, "Error binding socket: [%s %s %d] (%s)", ports[p].toCharArray(), ips[i].toCharArray(), idx, strerror(errno));
+                    return -1;
+                }
+                lc_types.push_back(CT_PROXY);
+                idx++;
+            }
+        }
+        return 0;
+    }
+
+    return -1;
 }
 
 // try connecting to all our sockets which are still open to allow tidy close


### PR DESCRIPTION
### Motivation

- Ensure correct tracking of listener connection types and support both one-to-one and IP×port matrix binding modes for multi-listen configurations.
- Advance the packaged release/version metadata to the next patch level.

### Description

- Added `lc_types.clear()` in `SocketArray::deleteAll()` and `SocketArray::reset()` to properly reset listener type state when sockets are reallocated.
- Reworked `SocketArray::bindAll()` to validate inputs, handle an explicit one-to-one IP/port mapping when `socknum == ips.size()`, and handle IP×port matrix binding when `socknum == ips.size() * ports.size()`, returning `-1` on invalid combinations; logs errors with `syslog` and preserves existing debug output.
- Ensured `lc_types.push_back(CT_PROXY)` is performed for each bound listener slot in both mapping modes and updated error branches to return immediately on bind failure.
- Bumped package/version strings: `AC_INIT` in `configure.ac` updated to `5.4.10_6` and `e2guardian.release` updated to reflect the `v5.4.10_6` stable branch.

### Testing

- Ran `./configure` and `make` to compile the changed sources and the build completed successfully. 
- Executed `make check` (project unit/integration tests) and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb30e87fc832ebe200c032ba581ef)