### PR TITLE
Refresh resolver config before DNS lookups and add graceful pid kill-with-timeout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_CHECK_FUNCS([strerror strstr strtol])
 AC_CHECK_FUNCS([setuid setgid umask seteuid setreuid setlocale])
 AC_SEARCH_LIBS([floor], [m])
 AC_SEARCH_LIBS([gethostbyname], [nsl])
+AC_SEARCH_LIBS([res_init], [resolv], [AC_DEFINE([HAVE_RES_INIT], [1], [Define to 1 if you have the res_init function.])])
 AC_SEARCH_LIBS([socket], [socket], [], [
 AC_CHECK_LIB(
 [socket], [socket], [LIBS="-lsocket -lnsl $LIBS"],

--- a/src/ConnectionHandler.cpp
+++ b/src/ConnectionHandler.cpp
@@ -32,10 +32,11 @@
 #include <cstdlib>
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/stat.h>
 #include <strings.h>
+#include <mutex>
 #include <fcntl.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <istream>
@@ -58,6 +59,39 @@ extern OptionContainer o;
 extern bool is_daemonised;
 extern std::atomic<bool> ttg;
 extern thread_local std::string thread_id;
+
+namespace {
+#ifdef HAVE_RES_INIT
+#ifndef _PATH_RESCONF
+#define _PATH_RESCONF "/etc/resolv.conf"
+#endif
+
+void refresh_resolver_config_if_needed()
+{
+    static std::mutex resolver_mutex;
+    static time_t resolver_mtime = 0;
+    struct stat resolv_stat;
+
+    if (stat(_PATH_RESCONF, &resolv_stat) != 0) {
+        return;
+    }
+
+    if (resolv_stat.st_mtime == resolver_mtime) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(resolver_mutex);
+    if (resolv_stat.st_mtime != resolver_mtime) {
+        res_init();
+        resolver_mtime = resolv_stat.st_mtime;
+    }
+}
+#else
+void refresh_resolver_config_if_needed()
+{
+}
+#endif
+}
 
 
 // IMPLEMENTATION
@@ -556,6 +590,7 @@ ConnectionHandler::connectUpstream(Socket &sock, NaughtyFilter &cm, int port = 0
                 hints.ai_canonname = NULL;
                 hints.ai_addr = NULL;
                 hints.ai_next = NULL;
+                refresh_resolver_config_if_needed();
                 int rc = getaddrinfo(cm.connect_site.toCharArray(), NULL, &hints, &infoptr);
                 if (rc)  // problem
                 {

--- a/src/SysV.cpp
+++ b/src/SysV.cpp
@@ -36,6 +36,18 @@ bool confirmname(pid_t p);
 
 // IMPLEMENTATION
 
+// wait until a process exits; returns true when it is no longer running
+bool wait_for_exit(pid_t p, int timeout_seconds)
+{
+    for (int waited = 0; waited < timeout_seconds; waited++) {
+        sleep(1);
+        if (!confirmname(p)) {
+            return true;
+        }
+    }
+    return !confirmname(p);
+}
+
 // grab the PID from the file & check it's running (returns -1 on failure)
 // (also checks process names if file method fails, but this is unimplemented)
 pid_t getpid(std::string pidfile)
@@ -120,6 +132,45 @@ int sysv_kill(std::string pidfile, bool dounlink)
     }
     std::cerr << "No e2guardian process found." << std::endl;
     return 1;
+}
+
+// kill process in the pidfile and wait for it to exit; escalate if it does not stop cleanly
+int sysv_kill_wait(std::string pidfile, int timeout_seconds, bool dounlink)
+{
+    pid_t p = getpid(pidfile);
+    if (p <= 1) {
+        return 0;
+    }
+
+    int rc = ::kill(p, SIGTERM);
+    if (rc == -1) {
+        std::cerr << "Error trying to kill pid:" << p << std::endl;
+        if (errno == EPERM) {
+            std::cerr << "Permission denied." << std::endl;
+        }
+        return 1;
+    }
+
+    if (!wait_for_exit(p, timeout_seconds)) {
+        std::cerr << "Timed out waiting for pid:" << p << "; sending SIGKILL" << std::endl;
+        rc = ::kill(p, SIGKILL);
+        if (rc == -1) {
+            std::cerr << "Error trying to force kill pid:" << p << std::endl;
+            if (errno == EPERM) {
+                std::cerr << "Permission denied." << std::endl;
+            }
+            return 1;
+        }
+        if (!wait_for_exit(p, 5)) {
+            std::cerr << "Timed out waiting for pid:" << p << " after SIGKILL" << std::endl;
+            return 1;
+        }
+    }
+
+    if (dounlink) {
+        unlink(pidfile.c_str());
+    }
+    return 0;
 }
 
 // send HUP to process

--- a/src/SysV.hpp
+++ b/src/SysV.hpp
@@ -17,6 +17,8 @@
 // Kill the process specified in the given pidfile, optionally deleting the pidfile while we're at it,
 // along with the UNIX domain sockets for the old logger & url cache
 int sysv_kill(std::string pidfile, bool dounlink = true);
+// Kill the pidfile process and wait for it to exit, escalating to SIGKILL after timeout_seconds.
+int sysv_kill_wait(std::string pidfile, int timeout_seconds = 30, bool dounlink = true);
 
 // show PID of running E2 process
 int sysv_showpid(std::string pidfile);

--- a/src/e2guardian.cpp
+++ b/src/e2guardian.cpp
@@ -108,10 +108,8 @@ int main(int argc, char *argv[])
                     return sysv_kill(o.pid_filename,true);
                 case 'Q':
                     read_config(configfile, 0);
-                    sysv_kill(o.pid_filename, false);
-                    // give the old process time to die
-                    while (sysv_amirunning(o.pid_filename))
-                        sleep(1);
+                    if (sysv_kill_wait(o.pid_filename, 30, false) != 0)
+                        return 1;
                     unlink(o.pid_filename.c_str());
                     // remember to reset config before continuing
                     needreset = true;


### PR DESCRIPTION
### Motivation
- Ensure DNS lookups see updates to `/etc/resolv.conf` in long-running threads by calling `res_init()` when the resolv file changes. 
- Provide a safer shutdown sequence that waits for a daemon to exit and escalates to `SIGKILL` if it does not stop within a timeout. 
- Expose a programmatic API to request a kill-and-wait with a configurable timeout for management commands.

### Description
- Added an `AC_SEARCH_LIBS` check for `res_init` in `configure.ac` and define `HAVE_RES_INIT` when available. 
- Implemented `refresh_resolver_config_if_needed()` in `src/ConnectionHandler.cpp` which checks `/etc/resolv.conf` mtime and calls `res_init()` under a mutex when the file changes, and call it before `getaddrinfo()` calls. 
- Added `wait_for_exit()` and `sysv_kill_wait()` implementations to `src/SysV.cpp` which send `SIGTERM`, wait up to `timeout_seconds`, then send `SIGKILL` if needed and optionally unlink the pidfile. 
- Declared `sysv_kill_wait()` in `src/SysV.hpp`. 
- Updated `src/e2guardian.cpp` to use `sysv_kill_wait()` for the `-Q` option to perform a timed graceful shutdown and escalate if necessary. 

### Testing
- Ran `./configure` to pick up `res_init` availability and regenerate build files, which completed successfully. 
- Built the project with `make`, and the build completed successfully without compiler errors. 
- Exercised the new shutdown path by building with the updated binary and invoking the `-Q` option in an automated CI job that verifies exit code behavior, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf32bcbe0832eacd0255a06629c68)