### PR TITLE
Reduce verbose IP auth syslog messages and add pfSense cron troubleshooting notes

### DIFF
--- a/doc/troubleshooting-ip-auth-group-drift.md
+++ b/doc/troubleshooting-ip-auth-group-drift.md
@@ -46,3 +46,35 @@ match to the first group if not validated strictly.
 Recent code logs a warning when `usexforwardedfor=on` and
 `xforwardedforfilterip` is empty, because this trusts `X-Forwarded-For` from
 all peers and can collapse user identification unexpectedly.
+
+## 5) pfSense cron scripts can trigger service restarts (timing correlation)
+
+In `Kontrol-pkg-E2guardian54`, the cron script
+`/usr/local/www/e2guardian_logrotate.php` explicitly stops and starts
+e2guardian during log rotation (`service_control_stop/start`), and also kills
+and later restarts the watchdog process. If your incident starts right after
+that cron window, correlate timestamps first.
+
+This script rotates only `/var/log/e2guardian/access.log` and does not edit
+`/usr/local/etc/e2guardian/lists/authplugins/ipgroups` directly. So by itself
+it should not remap users to group 1, but it can be the trigger point where
+e2guardian restarts and then loads a bad/empty runtime config produced by some
+other process.
+
+The blacklist updater cron (`/usr/local/www/e2guardian.php fetch_blacklist`)
+renames/extracts content under `.../lists/blacklists*` and writes pfSense
+package config metadata. It does not touch `authplugins/ipgroups` either, but
+it can indirectly trigger broader config reload/rewrite flows in pfSense.
+
+### Correlation checklist for cron-related incidents
+
+1. Compare incident start time with cron executions of:
+   - `php -q /usr/local/www/e2guardian_logrotate.php`
+   - `php /usr/local/www/e2guardian.php fetch_blacklist`
+2. If drift starts right after logrotate, check IP auth diagnostics for:
+   - `IP auth reloaded ipgroups ... ips=0 subnets=0 ranges=0`
+   - `IP auth reloaded empty ipgroups list ... size=... inode=... mtime=...`
+3. During the same minute, verify file state atomically:
+   - `ls -li /usr/local/etc/e2guardian/lists/authplugins/ipgroups`
+   - `wc -l  /usr/local/etc/e2guardian/lists/authplugins/ipgroups`
+4. Confirm no cron/job rewrites `ipgroups` path or symlink target.

--- a/src/authplugins/ip.cpp
+++ b/src/authplugins/ip.cpp
@@ -552,13 +552,6 @@ bool ipinstance::ensureIPGroupsLoadedLocked()
         iprangelist.swap(new_iprangelist);
         ipgroups_reload_id_ = current_reload_id;
         ipgroups_loaded_ = true;
-        syslog(LOG_NOTICE,
-               "IP auth reloaded ipgroups: path=%s reload_id=%d ips=%zu subnets=%zu ranges=%zu",
-               ipgroups_path_.c_str(),
-               ipgroups_reload_id_,
-               iplist.size(),
-               ipsubnetlist.size(),
-               iprangelist.size());
     }
 
     return ipgroups_loaded_;
@@ -585,9 +578,6 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
     SpecialIpGroup special = decode_hidden_group(fg);
     if (apply_hidden_group(special, user, cm)) {
         cm.filtergroup = rfg;
-        syslog(LOG_NOTICE, "IP auth decision: ip=%s source=iplist special=%s result=nogroup",
-               user.c_str(),
-               special == SpecialIpGroup::Banned ? "banned" : "exception");
         return E2AUTH_NOGROUP;
     }
     if (fg >= 0) {
@@ -602,19 +592,12 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
 #ifdef E2DEBUG
         std::cerr << thread_id << "Matched IP " << user << " to straight IP list" << std::endl;
 #endif
-        syslog(LOG_NOTICE,
-               "IP auth decision: ip=%s source=iplist result=group%d reason=exact_ip_match",
-               user.c_str(),
-               rfg + 1);
         return E2AUTH_OK;
     }
     fg = inSubnet(addr);
     special = decode_hidden_group(fg);
     if (apply_hidden_group(special, user, cm)) {
         cm.filtergroup = rfg;
-        syslog(LOG_NOTICE, "IP auth decision: ip=%s source=subnet special=%s result=nogroup",
-               user.c_str(),
-               special == SpecialIpGroup::Banned ? "banned" : "exception");
         return E2AUTH_NOGROUP;
     }
     if (fg >= 0) {
@@ -646,22 +629,12 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
         mask_addr.s_addr = htonl(matched_mask);
         inet_ntop(AF_INET, &net_addr, netbuf, sizeof(netbuf));
         inet_ntop(AF_INET, &mask_addr, maskbuf, sizeof(maskbuf));
-        syslog(LOG_NOTICE,
-               "IP auth decision: ip=%s source=subnet result=group%d reason=subnet_match network=%s mask=%s masked_ip=%s",
-               user.c_str(),
-               rfg + 1,
-               netbuf,
-               maskbuf,
-               (netbuf[0] != '\0') ? netbuf : "-");
         return E2AUTH_OK;
     }
     fg = inRange(addr);
     special = decode_hidden_group(fg);
     if (apply_hidden_group(special, user, cm)) {
         cm.filtergroup = rfg;
-        syslog(LOG_NOTICE, "IP auth decision: ip=%s source=range special=%s result=nogroup",
-               user.c_str(),
-               special == SpecialIpGroup::Banned ? "banned" : "exception");
         return E2AUTH_NOGROUP;
     }
     if (fg >= 0) {
@@ -693,26 +666,11 @@ int ipinstance::determineGroup(std::string &user, int &rfg, StoryBoard &story, N
         end_addr.s_addr = htonl(matched_end);
         inet_ntop(AF_INET, &start_addr, startbuf, sizeof(startbuf));
         inet_ntop(AF_INET, &end_addr, endbuf, sizeof(endbuf));
-        syslog(LOG_NOTICE,
-               "IP auth decision: ip=%s source=range result=group%d reason=range_match range_start=%s range_end=%s",
-               user.c_str(),
-               rfg + 1,
-               startbuf,
-               endbuf);
         return E2AUTH_OK;
     }
 #ifdef E2DEBUG
     std::cerr << thread_id << "Matched IP " << user << " to nothing" << std::endl;
 #endif
-    syslog(LOG_NOTICE,
-           "IP auth decision: ip=%s source=none result=nomatch default_group=%d reload_id=%d loaded=%d ips=%zu subnets=%zu ranges=%zu reason=no_exact_no_subnet_no_range",
-           user.c_str(),
-           rfg + 1,
-           ipgroups_reload_id_,
-           ipgroups_loaded_ ? 1 : 0,
-           iplist.size(),
-           ipsubnetlist.size(),
-           iprangelist.size());
     (void)story;
     return E2AUTH_NOMATCH;
 }


### PR DESCRIPTION
### Motivation

- Reduce noisy and redundant `syslog(LOG_NOTICE, ...)` messages emitted by IP auth logic to cut log spam while preserving group-determination behavior. 
- Document a real-world operational trigger where pfSense package cron scripts can restart e2guardian and cause timing-correlated IP auth drift to help operators diagnose incidents.

### Description

- Remove multiple `syslog(LOG_NOTICE, ...)` calls from `src/authplugins/ip.cpp`, including the ipgroups reload notice and per-decision notices for exact IP, subnet, range, special (banned/exception) and no-match cases. 
- Preserve the existing IP group matching and return-value logic; only logging statements were removed. 
- Add a new section to `doc/troubleshooting-ip-auth-group-drift.md` describing `Kontrol-pkg-E2guardian54` cron scripts (`e2guardian_logrotate.php` and `e2guardian.php fetch_blacklist`), their restart/rotation behavior, and a concise correlation checklist with commands to inspect file state and reload events.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1398ef4f14832ebf4ef792152422d9)